### PR TITLE
Add subdomain support

### DIFF
--- a/server/src/airtable-interface.js
+++ b/server/src/airtable-interface.js
@@ -44,7 +44,7 @@ async function getAllTableData(tableName, options = {}) {
 function customUpdater(tableName, item) {
     if (tableName === "Broadcasts" && item.key && item.active) Cache.set(`broadcast-${item.key}`, item);
     if (tableName === "Clients" && item.key) Cache.set(`client-${item.key}`, item);
-    if (tableName === "Events" && item.subdomain) Cache.set(`event-${item.subdomain}`, item);
+    if (tableName === "Events" && item.subdomain) Cache.set(`subdomain-${item.subdomain}`, item);
 }
 
 async function processTableData(tableName, data) {

--- a/website/public/assets/initial.css
+++ b/website/public/assets/initial.css
@@ -1,0 +1,4 @@
+body {
+    background-color: #222;
+    background: #222;
+}

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -4,8 +4,15 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
-<!--    <link rel="stylesheet" href="<%= BASE_URL %>assets/bootstrap.css">-->
-<!--    <link rel="stylesheet" href="<%= BASE_URL %>assets/app.css">-->
+      <script>
+          try {
+              if (window.obsstudio || ["client", "broadcast"].includes(window.location.pathname.split('/')[1])) {
+                  // stay transparent pls
+              } else {
+                  document.head.insertAdjacentHTML('beforeend', '<link rel="stylesheet" href="/assets/initial.css">')
+              }
+          } catch (e) { console.error(e); }
+      </script>
     <link rel="stylesheet" href="<%= BASE_URL %>assets/fa-all.css">
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>

--- a/website/src/apps/GlobalApp.vue
+++ b/website/src/apps/GlobalApp.vue
@@ -8,4 +8,7 @@
     #slmngg-app {
         background: transparent;
     }
+    body {
+        background-color: #202020;
+    }
 </style>

--- a/website/src/apps/MinisiteWrapperApp.vue
+++ b/website/src/apps/MinisiteWrapperApp.vue
@@ -1,6 +1,9 @@
 <template>
     <div class="minisite-wrapper-app">
-        <WebsiteApp v-if="event && (event._original_data_id || event.__loading)" :id="event._original_data_id"/>
+        <div id="app" v-if="event && (event._original_data_id || event.__loading)">
+            <WebsiteNav :minisite="event"/>
+            <router-view class="my-3 slmngg-page"/>
+        </div>
         <NotFoundPage v-else/>
     </div>
 </template>
@@ -9,13 +12,15 @@
 import Event from "@/views/Event";
 import NotFoundPage from "@/views/NotFoundPage";
 import WebsiteApp from "@/apps/WebsiteApp";
+import WebsiteNav from "@/components/website/WebsiteNav";
 
 export default {
     name: "MinisiteWrapperApp",
     components: {
         NotFoundPage,
         // Event,
-        WebsiteApp
+        // WebsiteApp,
+        WebsiteNav
     },
     computed: {
         event () {

--- a/website/src/apps/MinisiteWrapperApp.vue
+++ b/website/src/apps/MinisiteWrapperApp.vue
@@ -1,0 +1,35 @@
+<template>
+    <div class="minisite-wrapper-app">
+        <WebsiteApp v-if="event && (event._original_data_id || event.__loading)" :id="event._original_data_id"/>
+        <NotFoundPage v-else/>
+    </div>
+</template>
+
+<script>
+import Event from "@/views/Event";
+import NotFoundPage from "@/views/NotFoundPage";
+import WebsiteApp from "@/apps/WebsiteApp";
+
+export default {
+    name: "MinisiteWrapperApp",
+    components: {
+        NotFoundPage,
+        // Event,
+        WebsiteApp
+    },
+    computed: {
+        event () {
+            return this.$root.minisiteEvent;
+        }
+    },
+    beforeCreate () {
+        document.body.className = "website";
+    }
+};
+</script>
+
+<style scoped>
+@import "~@/assets/bootstrap.css";
+@import "~@/assets/app.css";
+
+</style>

--- a/website/src/apps/MinisiteWrapperApp.vue
+++ b/website/src/apps/MinisiteWrapperApp.vue
@@ -2,6 +2,23 @@
     <div class="minisite-wrapper-app">
         <div id="app" v-if="event && (event._original_data_id || event.__loading)">
             <WebsiteNav :minisite="event"/>
+            <v-style id="minisite-css">
+                body.minisite {
+                    background-color: {{ theme.color_body }};
+                    color: {{ theme.color_text_on_body }};
+                }
+                body.minisite nav {
+                    background-color: {{ theme.color_navbar }};
+                }
+                body.minisite .website-nav nav,
+                body.minisite .website-nav .navbar-brand,
+                body.minisite .website-nav .navbar-text {
+                    color: {{ nav_color }};
+                }
+                body.minisite .website-nav .nav-link { color: {{ nav_color }}7f !important; }
+                body.minisite .website-nav .nav-link:hover { color: {{ nav_color }}bf !important; }
+                body.minisite .website-nav .nav-link.active { color: {{ nav_color }}ff !important; }
+            </v-style>
             <router-view class="my-3 slmngg-page"/>
         </div>
         <NotFoundPage v-else/>
@@ -9,10 +26,9 @@
 </template>
 
 <script>
-import Event from "@/views/Event";
 import NotFoundPage from "@/views/NotFoundPage";
-import WebsiteApp from "@/apps/WebsiteApp";
 import WebsiteNav from "@/components/website/WebsiteNav";
+import { ReactiveThing } from "@/utils/reactive";
 
 export default {
     name: "MinisiteWrapperApp",
@@ -25,10 +41,21 @@ export default {
     computed: {
         event () {
             return this.$root.minisiteEvent;
+        },
+        theme() {
+            return ReactiveThing("theme")(this.event);
+        },
+        nav_color() {
+            if (!this.theme) return "#ffffff";
+            if (this.theme.color_navbar === this.theme.color_body) return this.theme.color_text_on_body;
+            if (this.theme.color_navbar === this.theme.color_theme) return this.theme.color_text_on_theme;
+            if (this.theme.color_navbar === this.theme.color_logo_background) return this.theme.color_text_on_logo_background;
+
+            return "#ffffff";
         }
     },
-    beforeCreate () {
-        document.body.className = "website";
+    mounted () {
+        document.body.classList.add("website", "minisite");
     }
 };
 </script>

--- a/website/src/apps/WebsiteApp.vue
+++ b/website/src/apps/WebsiteApp.vue
@@ -1,62 +1,21 @@
 <template>
     <div id="app">
-        <div class="development-bar bg-warning text-dark text-center py-1">
-            <b>In development:</b> things may break, be missing, or not appear as expected.
-        </div>
-        <b-navbar toggleable="lg" type="dark">
-            <router-link class="navbar-brand" to="/">SLMN.GG</router-link>
-
-            <b-navbar-toggle target="nav-collapse"></b-navbar-toggle>
-
-            <b-collapse id="nav-collapse" is-nav>
-                <b-navbar-nav>
-                    <router-link active-class="active" class="nav-link" to="/events">Events</router-link>
-                    <router-link active-class="active" class="nav-link" to="/teams">Teams</router-link>
-                    <router-link active-class="active" class="nav-link" to="/players">Players</router-link>
-                    <router-link active-class="active" class="nav-link" to="/news">News</router-link>
-                </b-navbar-nav>
-                <b-navbar-nav>
-                    <NavLiveMatch v-for="match in liveMatches" :match="match" v-bind:key="match.id" />
-                </b-navbar-nav>
-            </b-collapse>
-        </b-navbar>
-
+        <WebsiteNav/>
         <router-view class="my-3 slmngg-page"/>
     </div>
 </template>
 
 <script>
-
-import {
-    BCollapse,
-    BNavbar,
-    BNavbarNav,
-    BNavbarToggle
-} from "bootstrap-vue";
-
 import { ReactiveArray, ReactiveRoot, ReactiveThing } from "../utils/reactive";
-import NavLiveMatch from "../components/website/NavLiveMatch";
+import WebsiteNav from "@/components/website/WebsiteNav";
 
 export default {
     name: "WebsiteApp",
     components: {
-        BNavbar,
-        BNavbarToggle,
-        BCollapse,
-        BNavbarNav,
-        NavLiveMatch
+        WebsiteNav
     },
     beforeCreate () {
         document.body.className = "website";
-    },
-    computed: {
-        liveMatches() {
-            return ReactiveRoot("special:live-matches", {
-                matches: ReactiveArray("matches", {
-                    event: ReactiveThing("event")
-                })
-            }).matches;
-        }
     }
 };
 </script>

--- a/website/src/components/website/WebsiteNav.vue
+++ b/website/src/components/website/WebsiteNav.vue
@@ -4,19 +4,26 @@
             <b>In development:</b> things may break, be missing, or not appear as expected.
         </div>
         <b-navbar toggleable="lg" type="dark">
-            <router-link class="navbar-brand" to="/">SLMN.GG</router-link>
+            <router-link class="navbar-brand" to="/">{{ minisite ? (minisite.navbar_name || minisite.series_name || minisite.name) : "SLMN.GG"}}</router-link>
 
             <b-navbar-toggle target="nav-collapse"></b-navbar-toggle>
 
             <b-collapse id="nav-collapse" is-nav>
-                <b-navbar-nav>
+                <b-navbar-nav v-if="!minisite">
                     <router-link active-class="active" class="nav-link" to="/events">Events</router-link>
                     <router-link active-class="active" class="nav-link" to="/teams">Teams</router-link>
                     <router-link active-class="active" class="nav-link" to="/players">Players</router-link>
                     <router-link active-class="active" class="nav-link" to="/news">News</router-link>
                 </b-navbar-nav>
-                <b-navbar-nav>
+                <b-navbar-nav v-if="minisite">
+                    <router-link active-class="active" v-if="minisite.matches" class="nav-link" to="/schedule">Schedule</router-link>
+                    <router-link active-class="active" v-if="minisite.brackets" class="nav-link" to="/bracket">{{ minisite.brackets.length === 1 ? 'Bracket' : 'Brackets' }}</router-link>
+                </b-navbar-nav>
+                <b-navbar-nav class="mr-auto">
                     <NavLiveMatch v-for="match in liveMatches" :match="match" v-bind:key="match.id" />
+                </b-navbar-nav>
+                <b-navbar-nav v-if="minisite">
+                    <a :href="slmnggURL('')" class="nav-link">SLMN.GG</a>
                 </b-navbar-nav>
             </b-collapse>
         </b-navbar>
@@ -42,6 +49,7 @@ export default {
         BNavbarNav,
         NavLiveMatch
     },
+    props: ["minisite"],
     computed: {
         liveMatches() {
             return ReactiveRoot("special:live-matches", {
@@ -49,6 +57,19 @@ export default {
                     event: ReactiveThing("event")
                 })
             }).matches;
+        },
+        slmnggDomain() {
+            console.log("env", process.env);
+            try {
+                return process.env.NODE_ENV === "development" ? "http://localhost:8080" : "https://dev.slmn.gg";
+            } catch (e) {
+                return "https://dev.slmn.gg";
+            }
+        }
+    },
+    methods: {
+        slmnggURL(page) {
+            return `${this.slmnggDomain}/${page}`;
         }
     }
 };

--- a/website/src/components/website/WebsiteNav.vue
+++ b/website/src/components/website/WebsiteNav.vue
@@ -1,0 +1,59 @@
+<template>
+    <div class="website-nav">
+        <div class="development-bar bg-warning text-dark text-center py-1">
+            <b>In development:</b> things may break, be missing, or not appear as expected.
+        </div>
+        <b-navbar toggleable="lg" type="dark">
+            <router-link class="navbar-brand" to="/">SLMN.GG</router-link>
+
+            <b-navbar-toggle target="nav-collapse"></b-navbar-toggle>
+
+            <b-collapse id="nav-collapse" is-nav>
+                <b-navbar-nav>
+                    <router-link active-class="active" class="nav-link" to="/events">Events</router-link>
+                    <router-link active-class="active" class="nav-link" to="/teams">Teams</router-link>
+                    <router-link active-class="active" class="nav-link" to="/players">Players</router-link>
+                    <router-link active-class="active" class="nav-link" to="/news">News</router-link>
+                </b-navbar-nav>
+                <b-navbar-nav>
+                    <NavLiveMatch v-for="match in liveMatches" :match="match" v-bind:key="match.id" />
+                </b-navbar-nav>
+            </b-collapse>
+        </b-navbar>
+    </div>
+</template>
+
+<script>
+import {
+    BCollapse,
+    BNavbar,
+    BNavbarNav,
+    BNavbarToggle
+} from "bootstrap-vue";
+import NavLiveMatch from "@/components/website/NavLiveMatch";
+import { ReactiveArray, ReactiveRoot, ReactiveThing } from "@/utils/reactive";
+
+export default {
+    name: "WebsiteNav",
+    components: {
+        BNavbar,
+        BNavbarToggle,
+        BCollapse,
+        BNavbarNav,
+        NavLiveMatch
+    },
+    computed: {
+        liveMatches() {
+            return ReactiveRoot("special:live-matches", {
+                matches: ReactiveArray("matches", {
+                    event: ReactiveThing("event")
+                })
+            }).matches;
+        }
+    }
+};
+</script>
+
+<style scoped>
+
+</style>

--- a/website/src/main.js
+++ b/website/src/main.js
@@ -48,7 +48,10 @@ const app = new Vue({
     },
     metaInfo: {
         title: "SLMN.GG",
-        titleTemplate: "%s | SLMN.GG"
+        titleTemplate: "%s | SLMN.GG",
+        link: [
+            { rel: "icon", href: "https://slmn.io/slmn-new.png" }
+        ]
     },
     data: () => ({ interval: null }),
     mounted() {

--- a/website/src/main.js
+++ b/website/src/main.js
@@ -14,6 +14,7 @@ import EventRoutes from "@/router/event";
 
 import Event from "@/views/Event";
 import MinisiteWrapperApp from "@/apps/MinisiteWrapperApp";
+import NotFoundPage from "@/views/NotFoundPage";
 
 Vue.use(Vuex);
 Vue.use(VueMeta);
@@ -74,7 +75,8 @@ if (subdomain) {
                     }
                 }
             ]
-        }
+        },
+        { path: "/*", component: NotFoundPage }
     ];
 } else {
     // default slmn.gg

--- a/website/src/main.js
+++ b/website/src/main.js
@@ -15,6 +15,7 @@ import EventRoutes from "@/router/event";
 import Event from "@/views/Event";
 import MinisiteWrapperApp from "@/apps/MinisiteWrapperApp";
 import NotFoundPage from "@/views/NotFoundPage";
+import SharedRoutes from "@/router/shared-routes";
 
 Vue.use(Vuex);
 Vue.use(VueMeta);
@@ -73,7 +74,8 @@ if (subdomain) {
                             isMinisite: true
                         };
                     }
-                }
+                },
+                ...SharedRoutes
             ]
         },
         { path: "/*", component: NotFoundPage }

--- a/website/src/router/default.js
+++ b/website/src/router/default.js
@@ -1,26 +1,15 @@
-import WebsiteApp from "@/apps/WebsiteApp";
 import Home from "@/views/Home";
-import Team from "@/views/Team";
-import TeamMain from "@/views/sub-views/TeamMain";
-import TeamMatches from "@/views/sub-views/TeamMatches";
-import TeamTheme from "@/views/sub-views/TeamTheme";
-import TeamDetails from "@/views/sub-views/TeamDetails";
 import Events from "@/views/lists/Events";
 import Teams from "@/views/lists/Teams";
 import Players from "@/views/lists/Players";
-import Event from "@/views/Event";
-import EventRoutes from "@/router/event";
-import Player from "@/views/Player";
-import PlayerMain from "@/views/sub-views/PlayerMain";
-import PlayerCasts from "@/views/sub-views/PlayerCasts";
-import PlayerNews from "@/views/sub-views/PlayerNews";
-import PlayerMatches from "@/views/sub-views/PlayerMatches";
-import PlayerPlayedMatches from "@/views/sub-views/PlayerPlayedMatches";
-import Match from "@/views/Match";
-import OverlayApp from "@/apps/BroadcastApp";
-import BroadcastRoutes from "@/router/broadcast";
-import ClientApp from "@/apps/ClientApp";
 import NotFoundPage from "@/views/NotFoundPage";
+
+import WebsiteApp from "@/apps/WebsiteApp";
+import OverlayApp from "@/apps/BroadcastApp";
+import ClientApp from "@/apps/ClientApp";
+
+import BroadcastRoutes from "@/router/broadcast";
+import SharedRoutes from "@/router/shared-routes";
 
 export default [
     {
@@ -33,42 +22,10 @@ export default [
                 // name: "Home",
                 component: Home
             },
-            {
-                path: "/team/:id",
-                // name: "Team",
-                component: Team,
-                props: route => ({ id: route.params.id }),
-                children: [
-                    { path: "", component: TeamMain },
-                    { path: "matches", component: TeamMatches },
-                    { path: "theme", component: TeamTheme },
-                    { path: "details", component: TeamDetails }
-                ]
-            },
             { path: "/events", component: Events },
             { path: "/teams", component: Teams },
             { path: "/players", component: Players },
-            {
-                path: "/event/:id",
-                // name: "Event",
-                component: Event,
-                props: route => ({ id: route.params.id }),
-                children: EventRoutes
-            },
-            {
-                path: "/player/:id",
-                // name: "Player",
-                component: Player,
-                props: route => ({ id: route.params.id }),
-                children: [
-                    { path: "", component: PlayerMain },
-                    { path: "casts", component: PlayerCasts },
-                    { path: "news", component: PlayerNews },
-                    { path: "matches", component: PlayerMatches },
-                    { path: "played-matches", component: PlayerPlayedMatches }
-                ]
-            },
-            { path: "/match/:id", component: Match, props: route => ({ id: route.params.id }) },
+            ...SharedRoutes,
             {
                 path: "/about",
                 // name: "About",

--- a/website/src/router/default.js
+++ b/website/src/router/default.js
@@ -20,6 +20,7 @@ import Match from "@/views/Match";
 import OverlayApp from "@/apps/BroadcastApp";
 import BroadcastRoutes from "@/router/broadcast";
 import ClientApp from "@/apps/ClientApp";
+import NotFoundPage from "@/views/NotFoundPage";
 
 export default [
     {
@@ -89,5 +90,9 @@ export default [
         component: ClientApp,
         props: route => ({ client: route.params.clientID }),
         children: BroadcastRoutes
+    },
+    {
+        path: "/*",
+        component: NotFoundPage
     }
 ];

--- a/website/src/router/default.js
+++ b/website/src/router/default.js
@@ -1,0 +1,93 @@
+import WebsiteApp from "@/apps/WebsiteApp";
+import Home from "@/views/Home";
+import Team from "@/views/Team";
+import TeamMain from "@/views/sub-views/TeamMain";
+import TeamMatches from "@/views/sub-views/TeamMatches";
+import TeamTheme from "@/views/sub-views/TeamTheme";
+import TeamDetails from "@/views/sub-views/TeamDetails";
+import Events from "@/views/lists/Events";
+import Teams from "@/views/lists/Teams";
+import Players from "@/views/lists/Players";
+import Event from "@/views/Event";
+import EventRoutes from "@/router/event";
+import Player from "@/views/Player";
+import PlayerMain from "@/views/sub-views/PlayerMain";
+import PlayerCasts from "@/views/sub-views/PlayerCasts";
+import PlayerNews from "@/views/sub-views/PlayerNews";
+import PlayerMatches from "@/views/sub-views/PlayerMatches";
+import PlayerPlayedMatches from "@/views/sub-views/PlayerPlayedMatches";
+import Match from "@/views/Match";
+import OverlayApp from "@/apps/BroadcastApp";
+import BroadcastRoutes from "@/router/broadcast";
+import ClientApp from "@/apps/ClientApp";
+
+export default [
+    {
+        path: "/",
+        name: "default",
+        component: WebsiteApp,
+        children: [
+            {
+                path: "/",
+                // name: "Home",
+                component: Home
+            },
+            {
+                path: "/team/:id",
+                // name: "Team",
+                component: Team,
+                props: route => ({ id: route.params.id }),
+                children: [
+                    { path: "", component: TeamMain },
+                    { path: "matches", component: TeamMatches },
+                    { path: "theme", component: TeamTheme },
+                    { path: "details", component: TeamDetails }
+                ]
+            },
+            { path: "/events", component: Events },
+            { path: "/teams", component: Teams },
+            { path: "/players", component: Players },
+            {
+                path: "/event/:id",
+                // name: "Event",
+                component: Event,
+                props: route => ({ id: route.params.id }),
+                children: EventRoutes
+            },
+            {
+                path: "/player/:id",
+                // name: "Player",
+                component: Player,
+                props: route => ({ id: route.params.id }),
+                children: [
+                    { path: "", component: PlayerMain },
+                    { path: "casts", component: PlayerCasts },
+                    { path: "news", component: PlayerNews },
+                    { path: "matches", component: PlayerMatches },
+                    { path: "played-matches", component: PlayerPlayedMatches }
+                ]
+            },
+            { path: "/match/:id", component: Match, props: route => ({ id: route.params.id }) },
+            {
+                path: "/about",
+                // name: "About",
+                // route level code-splitting
+                // this generates a separate chunk (about.[hash].js) for this route
+                // which is lazy-loaded when the route is visited.
+                component: () => import(/* webpackChunkName: "about" */ "../views/About.vue")
+            }
+        ]
+    },
+    {
+        path: "/broadcast/:broadcastCode",
+        component: OverlayApp,
+        props: route => ({ code: route.params.broadcastCode, title: route.query.title, top: route.query.top }),
+        children: BroadcastRoutes
+    },
+    {
+        path: "/client/:clientID",
+        component: ClientApp,
+        props: route => ({ client: route.params.clientID }),
+        children: BroadcastRoutes
+    }
+];

--- a/website/src/router/event.js
+++ b/website/src/router/event.js
@@ -1,0 +1,18 @@
+import EventMain from "@/views/sub-views/EventMain";
+import EventRosters from "@/views/sub-views/EventRosters";
+import EventBrackets from "@/views/sub-views/EventBrackets";
+import EventSchedule from "@/views/sub-views/EventSchedule";
+import EventScenarios from "@/components/website/EventScenarios";
+import EventDraft from "@/views/sub-views/EventDraft";
+
+export default [
+    { path: "", component: EventMain },
+    { path: "rosters", component: EventRosters },
+    { path: "bracket", component: EventBrackets },
+    { path: "brackets", redirect: "bracket" },
+    { path: "schedule", component: EventSchedule },
+    { path: "matches", redirect: "schedule" },
+    { path: "scenarios", component: EventScenarios },
+    // { path: "scenarios2", component: EventScenarios2 },
+    { path: "draft", component: EventDraft }
+];

--- a/website/src/router/index.js
+++ b/website/src/router/index.js
@@ -1,115 +1,37 @@
 import Vue from "vue";
 import VueRouter from "vue-router";
-import Home from "../views/Home.vue";
-import Team from "@/views/Team";
-import Event from "@/views/Event";
-import Player from "@/views/Player";
 import WebsiteApp from "@/apps/WebsiteApp";
-import OverlayApp from "@/apps/BroadcastApp";
-
-import PlayerMain from "@/views/sub-views/PlayerMain";
-import PlayerCasts from "@/views/sub-views/PlayerCasts";
-import PlayerNews from "@/views/sub-views/PlayerNews";
-import PlayerMatches from "@/views/sub-views/PlayerMatches";
-import Events from "@/views/lists/Events";
-import Teams from "@/views/lists/Teams";
-import TeamMain from "@/views/sub-views/TeamMain";
-import TeamMatches from "@/views/sub-views/TeamMatches";
-import PlayerPlayedMatches from "@/views/sub-views/PlayerPlayedMatches";
-import Match from "@/views/Match";
-import EventMain from "@/views/sub-views/EventMain";
-import EventRosters from "@/views/sub-views/EventRosters";
-import EventBrackets from "@/views/sub-views/EventBrackets";
-import TeamTheme from "@/views/sub-views/TeamTheme";
-import EventSchedule from "@/views/sub-views/EventSchedule";
-import EventScenarios from "@/components/website/EventScenarios";
-import EventDraft from "@/views/sub-views/EventDraft";
-import TeamDetails from "@/views/sub-views/TeamDetails";
-import BroadcastRoutes from "@/router/broadcast";
-import ClientApp from "@/apps/ClientApp";
-import Players from "@/views/lists/Players";
+import defaultRoutes from "@/router/default";
+import LoadingPage from "@/views/LoadingPage";
 
 Vue.use(VueRouter);
 
-const routes = [
-    {
-        path: "/",
-        component: WebsiteApp,
-        children: [
-            {
-                path: "/",
-                // name: "Home",
-                component: Home
-            },
-            {
-                path: "/team/:id",
-                // name: "Team",
-                component: Team,
-                props: route => ({ id: route.params.id }),
-                children: [
-                    { path: "", component: TeamMain },
-                    { path: "matches", component: TeamMatches },
-                    { path: "theme", component: TeamTheme },
-                    { path: "details", component: TeamDetails }
-                ]
-            },
-            { path: "/events", component: Events },
-            { path: "/teams", component: Teams },
-            { path: "/players", component: Players },
-            {
-                path: "/event/:id",
-                // name: "Event",
-                component: Event,
-                props: route => ({ id: route.params.id }),
-                children: [
-                    { path: "", component: EventMain },
-                    { path: "rosters", component: EventRosters },
-                    { path: "bracket", component: EventBrackets },
-                    { path: "brackets", redirect: "bracket" },
-                    { path: "schedule", component: EventSchedule },
-                    { path: "matches", redirect: "schedule" },
-                    { path: "scenarios", component: EventScenarios },
-                    // { path: "scenarios2", component: EventScenarios2 },
-                    { path: "draft", component: EventDraft }
-                ]
-            },
-            {
-                path: "/player/:id",
-                // name: "Player",
-                component: Player,
-                props: route => ({ id: route.params.id }),
-                children: [
-                    { path: "", component: PlayerMain },
-                    { path: "casts", component: PlayerCasts },
-                    { path: "news", component: PlayerNews },
-                    { path: "matches", component: PlayerMatches },
-                    { path: "played-matches", component: PlayerPlayedMatches }
-                ]
-            },
-            { path: "/match/:id", component: Match, props: route => ({ id: route.params.id }) },
-            {
-                path: "/about",
-                // name: "About",
-                // route level code-splitting
-                // this generates a separate chunk (about.[hash].js) for this route
-                // which is lazy-loaded when the route is visited.
-                component: () => import(/* webpackChunkName: "about" */ "../views/About.vue")
-            }
-        ]
-    },
-    {
-        path: "/broadcast/:broadcastCode",
-        component: OverlayApp,
-        props: route => ({ code: route.params.broadcastCode, title: route.query.title, top: route.query.top }),
-        children: BroadcastRoutes
-    },
-    {
-        path: "/client/:clientID",
-        component: ClientApp,
-        props: route => ({ client: route.params.clientID }),
-        children: BroadcastRoutes
+const host = window.location.hostname;
+const domains = ["slmn.gg", "localslmn", "localhost"].map(d => new RegExp(`(?:^|(.*)\\.)${d.replace(".", "\\.")}(?:$|\\n)`));
+let subdomain = null;
+
+domains.forEach(r => {
+    const result = host.match(r);
+    if (result && result[1]) {
+        subdomain = result[1];
     }
-];
+});
+
+let routes = [];
+
+if (subdomain) {
+    /* start with only one route, loading route
+    *
+    * once we have verified & loaded the event, add other routes
+    * if unverified, add a 404 */
+
+    routes = [
+        { path: "/", name: "default", component: WebsiteApp, children: [{ path: "*", component: LoadingPage }] }
+    ];
+} else {
+    routes = defaultRoutes;
+}
+
 
 const router = new VueRouter({
     mode: "history",

--- a/website/src/router/index.js
+++ b/website/src/router/index.js
@@ -3,6 +3,7 @@ import VueRouter from "vue-router";
 import WebsiteApp from "@/apps/WebsiteApp";
 import defaultRoutes from "@/router/default";
 import LoadingPage from "@/views/LoadingPage";
+import MinisiteWrapperApp from "@/apps/MinisiteWrapperApp";
 
 Vue.use(VueRouter);
 
@@ -26,7 +27,7 @@ if (subdomain) {
     * if unverified, add a 404 */
 
     routes = [
-        { path: "/", name: "default", component: WebsiteApp, children: [{ path: "*", component: LoadingPage }] }
+        { path: "/", name: "default", component: WebsiteApp, children: [{ path: "*", component: MinisiteWrapperApp }] }
     ];
 } else {
     routes = defaultRoutes;

--- a/website/src/router/shared-routes.js
+++ b/website/src/router/shared-routes.js
@@ -1,0 +1,50 @@
+import Team from "@/views/Team";
+import TeamMain from "@/views/sub-views/TeamMain";
+import TeamMatches from "@/views/sub-views/TeamMatches";
+import TeamTheme from "@/views/sub-views/TeamTheme";
+import TeamDetails from "@/views/sub-views/TeamDetails";
+import Event from "@/views/Event";
+import EventRoutes from "@/router/event";
+import Player from "@/views/Player";
+import PlayerMain from "@/views/sub-views/PlayerMain";
+import PlayerCasts from "@/views/sub-views/PlayerCasts";
+import PlayerNews from "@/views/sub-views/PlayerNews";
+import PlayerMatches from "@/views/sub-views/PlayerMatches";
+import PlayerPlayedMatches from "@/views/sub-views/PlayerPlayedMatches";
+import Match from "@/views/Match";
+
+export default [
+    {
+        path: "/team/:id",
+        // name: "Team",
+        component: Team,
+        props: route => ({ id: route.params.id }),
+        children: [
+            { path: "", component: TeamMain },
+            { path: "matches", component: TeamMatches },
+            { path: "theme", component: TeamTheme },
+            { path: "details", component: TeamDetails }
+        ]
+    },
+    {
+        path: "/event/:id",
+        // name: "Event",
+        component: Event,
+        props: route => ({ id: route.params.id }),
+        children: EventRoutes
+    },
+    {
+        path: "/player/:id",
+        // name: "Player",
+        component: Player,
+        props: route => ({ id: route.params.id }),
+        children: [
+            { path: "", component: PlayerMain },
+            { path: "casts", component: PlayerCasts },
+            { path: "news", component: PlayerNews },
+            { path: "matches", component: PlayerMatches },
+            { path: "played-matches", component: PlayerPlayedMatches }
+        ]
+    },
+    { path: "/match/:id", component: Match, props: route => ({ id: route.params.id }) }
+];

--- a/website/src/thing-store.js
+++ b/website/src/thing-store.js
@@ -17,8 +17,7 @@ export default new Vuex.Store({
     },
     mutations: {
         push(_store, { id, data }) {
-            // console.log(data);
-            data = JSON.parse(JSON.stringify({ ...data, id: cleanID(id), __stored: true }));
+            data = JSON.parse(JSON.stringify({ ...data, id: cleanID(id), _original_data_id: cleanID(data.id), __stored: true }));
             // if ()
 
             const index = this.state.things.findIndex(t => t.id === id);

--- a/website/src/utils/fetch.js
+++ b/website/src/utils/fetch.js
@@ -72,7 +72,7 @@ export async function fetchThings (ids) {
                 data: item
             });
             if (cleanID(item.id) !== item.__id) {
-                console.log("[custom update]", item.__id);
+                console.log("[custom update]", item.__id, item.id);
                 store.commit("push", {
                     id: item.__id,
                     data: item

--- a/website/src/utils/fetch.js
+++ b/website/src/utils/fetch.js
@@ -33,7 +33,7 @@ export async function fetchThing (id) {
     //         id, data: { __loading: true }
     //     });
     //
-    //     let data = await fetch(`${process.env.NODE_ENV === "development" ? "http://localhost:8901" : "https://data.slmn.gg"}/thing/${id}`).then(res => res.json());
+    //     let data = await fetch(`${process.env.NODE_ENV === "development" ? "http://localslmn:8901" : "https://data.slmn.gg"}/thing/${id}`).then(res => res.json());
     //     if (data.error) {
     //         console.error(data.message);
     //         data = { id: id, __fetch_failed: true };
@@ -60,7 +60,7 @@ export async function fetchThings (ids) {
             id, data: { __loading: true }
         }));
 
-        const data = await fetch(`${process.env.NODE_ENV === "development" ? "http://localhost:8901" : "https://data.slmn.gg"}/things/${ids.join(",")}`).then(res => res.json());
+        const data = await fetch(`${process.env.NODE_ENV === "development" ? "http://localslmn:8901" : "https://data.slmn.gg"}/things/${ids.join(",")}`).then(res => res.json());
 
         if (data.error) {
             console.error(data.message);
@@ -128,4 +128,8 @@ export async function getThings(ids) {
     console.log("[socket]", `resolving ${ids.length} things`);
     await fetchThings(ids);
     return ids.map(id => getThing(id));
+}
+
+export async function getAndWait(id) {
+
 }

--- a/website/src/views/Event.vue
+++ b/website/src/views/Event.vue
@@ -5,8 +5,8 @@
         <SubPageNav class="my-2">
             <li class="nav-item"><router-link class="nav-link" :to="subLink('')">Overview</router-link></li>
 <!--            <li class="nav-item"><router-link class="nav-link" :to="subLink('rosters')">Rosters</router-link></li>-->
-            <li class="nav-item" v-if="event.brackets"><router-link class="nav-link" :to="subLink('bracket')">{{ event.brackets.length === 1 ? 'Bracket' : 'Brackets' }}</router-link></li>
             <li class="nav-item" v-if="event.matches"><router-link class="nav-link" :to="subLink('schedule')">Schedule</router-link></li>
+            <li class="nav-item" v-if="event.brackets"><router-link class="nav-link" :to="subLink('bracket')">{{ event.brackets.length === 1 ? 'Bracket' : 'Brackets' }}</router-link></li>
             <li class="nav-item" v-if="showFoldy"><router-link class="nav-link" :to="subLink('scenarios')">Foldy Sheet</router-link></li>
             <li class="nav-item" v-if="showDraft"><router-link class="nav-link" :to="subLink('draft')">Draft</router-link></li>
 <!--            <li class="nav-item" v-if="team.matches"><router-link class="nav-link" :to="subLink('matches')">Matches</router-link></li>-->

--- a/website/src/views/Event.vue
+++ b/website/src/views/Event.vue
@@ -25,7 +25,7 @@ import SubPageNav from "@/components/website/SubPageNav";
 
 export default {
     name: "Event",
-    props: ["id"],
+    props: ["id", "isMinisite"],
     components: {
         ThingTop, SubPageNav
     },
@@ -42,7 +42,7 @@ export default {
     },
     computed: {
         event() {
-            return ReactiveRoot(this.id, {
+            return ReactiveRoot(this.isMinisite ? this.$root.minisiteEvent.id : this.id, {
                 theme: ReactiveThing("theme"),
                 teams: ReactiveArray("teams", {
                     theme: ReactiveThing("theme")
@@ -69,8 +69,14 @@ export default {
             return this.settings?.draft?.use || false;
         }
     },
+    mounted() {
+        console.log("[event mount]", this.id, this.event, this.$root.minisiteEvent);
+    },
     methods: {
         subLink(page) {
+            if (this.isMinisite) {
+                return `/${page}`;
+            }
             return `/event/${this.event.id}/${page}`;
         }
     }

--- a/website/src/views/LoadingPage.vue
+++ b/website/src/views/LoadingPage.vue
@@ -1,0 +1,16 @@
+<template>
+    <div class="container">
+        Loading custom event minisite...
+        {{ $root.minisiteEventStatus }}
+    </div>
+</template>
+
+<script>
+export default {
+    name: "LoadingPage"
+};
+</script>
+
+<style scoped>
+
+</style>

--- a/website/src/views/NotFoundPage.vue
+++ b/website/src/views/NotFoundPage.vue
@@ -1,15 +1,26 @@
 <template>
-    <div class="container">
-        Not Found Page
+    <div id="app">
+        <WebsiteNav/>
+        <div class="container my-3">
+            <h1 class="text-center">Not Found</h1>
+        </div>
     </div>
 </template>
 
 <script>
+import WebsiteNav from "@/components/website/WebsiteNav";
+
 export default {
-    name: "NotFoundPage"
+    name: "NotFoundPage",
+    components: { WebsiteNav },
+    beforeCreate () {
+        document.body.className = "website";
+    }
 };
 </script>
 
 <style scoped>
+@import "~@/assets/bootstrap.css";
+@import "~@/assets/app.css";
 
 </style>

--- a/website/src/views/NotFoundPage.vue
+++ b/website/src/views/NotFoundPage.vue
@@ -1,0 +1,15 @@
+<template>
+    <div class="container">
+        Not Found Page
+    </div>
+</template>
+
+<script>
+export default {
+    name: "NotFoundPage"
+};
+</script>
+
+<style scoped>
+
+</style>

--- a/website/src/views/lists/Players.vue
+++ b/website/src/views/lists/Players.vue
@@ -53,6 +53,11 @@ export default {
                 .replace(/3/g, "e")
                 .replace(/2/g, "a");
         }
+    },
+    metaInfo() {
+        return {
+            title: "Players"
+        };
     }
 };
 </script>

--- a/website/src/views/lists/Teams.vue
+++ b/website/src/views/lists/Teams.vue
@@ -52,6 +52,11 @@ export default {
             });
             return groups;
         }
+    },
+    metaInfo() {
+        return {
+            title: "Teams"
+        };
     }
 };
 </script>

--- a/website/vue.config.js
+++ b/website/vue.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+    devServer: {
+        disableHostCheck: true
+    }
+};


### PR DESCRIPTION
As in #13:

SLMN.GG allows some remapping and style changes for some events and teams, for example:

slmn.gg/event/-bpl-id- -> bpl.slmn.gg
slmn.gg/event/-bpl-id-/teams -> bpl.slmn.gg/teams

Expected functionality:

- [x] bpl.slmn.gg -> slmn.gg/event/recBPL
- [x] bpl.slmn.gg/schedule -> slmn.gg/event/recBPL/schedule
- [x] bpl.slmn.gg/bracket -> slmn.gg/event/recBPL/bracket
- [x] aaa.slmn.gg -> 404
- [x] aaa.slmn.gg/bracket -> 404
- [x] bpl.slmn.gg/team/rec... -> slmn.gg/team/rec...
- [x] bpl.slmn.gg/match/rec... -> slmn.gg/match/rec...
- [x] bpl.slmn.gg/event/rec... -> slmn.gg/event/rec... ?

There is a discussion on what should still be accessible from a minisite page. Where should a minsite end? Should the minisite open other events in a new tab on slmn.gg at some point?