### PR TITLE
Make staff names on the detailed match page clickable like the regular match page

### DIFF
--- a/website/src/components/website/DetailedMatchStat.vue
+++ b/website/src/components/website/DetailedMatchStat.vue
@@ -13,7 +13,6 @@
 </template>
 
 <script>
-import { url } from "@/utils/content-utils";
 import LinkedPlayers from "@/components/website/LinkedPlayers";
 
 export default {
@@ -21,7 +20,6 @@ export default {
     props: ["data", "text", "format", "raw", "time", "override", "match", "players"],
     components: { LinkedPlayers },
     methods: {
-        url,
         prettyDate: (tstr, split = "<br>") => {
             if (!tstr) return "No time set";
             const date = new Date(tstr);

--- a/website/src/components/website/DetailedMatchStat.vue
+++ b/website/src/components/website/DetailedMatchStat.vue
@@ -3,6 +3,9 @@
         <div class="stat-a"><slot></slot></div>
         <div class="stat-b" v-if="time">{{ prettyDate(match[data], ' ') }} local time</div>
         <div class="stat-b" v-else-if="raw" v-html="format ? format(match[data]) : match[data]"></div>
+        <div class="stat-b" v-else-if="players">
+            <LinkedPlayers :players="match[data] || override" />
+        </div>
         <div class="stat-b" v-else-if="override">{{ format ? format(override) : override }}</div>
         <div class="stat-b" v-else>{{ format ? format(match[data]) : match[data] }}</div>
 
@@ -10,14 +13,15 @@
 </template>
 
 <script>
+import { url } from "@/utils/content-utils";
+import LinkedPlayers from "@/components/website/LinkedPlayers";
+
 export default {
     name: "DetailedMatchStat",
-    props: ["data", "text", "format", "raw", "time", "override", "match"],
-
+    props: ["data", "text", "format", "raw", "time", "override", "match", "players"],
+    components: { LinkedPlayers },
     methods: {
-        getURL (text) {
-            return new URL(text);
-        },
+        url,
         prettyDate: (tstr, split = "<br>") => {
             if (!tstr) return "No time set";
             const date = new Date(tstr);

--- a/website/src/views/DetailedMatch.vue
+++ b/website/src/views/DetailedMatch.vue
@@ -85,7 +85,7 @@
                 <div class="info-block">
                     <stat :match="match" data="custom_name">Custom match name</stat>
                     <stat :match="match" data="match_number">Match number</stat>
-                    <stat :match="match" data="casters" :format="(d) => d.map(c => c.name).join(', ')">Casters</stat>
+                    <stat :match="match" data="casters" :players="true">Casters</stat>
                     <stat :match="match" data="sub_event">Sub Event</stat>
 <!-- TODO: change this to spacetime -->
                     <stat :match="match" data="start" time="true">Scheduled start time</stat>
@@ -93,8 +93,7 @@
                     <stat :match="match" data="clean_feed" :format="(e) => `<a href='${e}' target='_blank'>${getURL(e).hostname}</a>`" raw="true">Clean Feed</stat>
                     <stat :match="match" data="first_to">First to</stat>
                     <stat :match="match" v-for="relGroup in playerRelationshipGroups" v-bind:key="relGroup.meta.singular_name"
-                          :override="relGroup.items"
-                          :format="(d) => d.map(c => c.name).join(', ')">
+                          :override="relGroup.items" :players="true">
                         {{ relGroup.items.length === 1 ? relGroup.meta.singular_name : relGroup.meta.plural_name }}</stat>
                     <stat :match="match" data="replay_codes" :raw="true" :format="(t) => t[0].replace(/\n/g, '<br>')">Replay codes</stat>
                 </div>


### PR DESCRIPTION
Replaces this
![image](https://user-images.githubusercontent.com/23165606/137588235-3b716187-cc98-4c29-a858-aac8feea497c.png)
with this
![image](https://user-images.githubusercontent.com/23165606/137588252-7d28e537-20be-4da8-9b89-67928274f56d.png)
