### PR TITLE
Make Syncer be at the top of page instead of centered

### DIFF
--- a/website/src/components/broadcast/roots/SyncerOverlay.vue
+++ b/website/src/components/broadcast/roots/SyncerOverlay.vue
@@ -4,7 +4,7 @@
             <IngameOverlay id="overlay" :broadcast="broadcast" v-if="showOverlay" />
         </transition>
         <transition name="fade">
-            <iframe class="w-100 h-100 position-absolute border-0" src="https://syncer.live/?embed" v-if="showSyncer"/>
+            <iframe class="w-100 h-100 position-absolute border-0" src="https://syncer.live/?embed&noCenter" v-if="showSyncer"/>
         </transition>
     </div>
 </template>


### PR DESCRIPTION
![2022-01-05 02 12 36 syncer live 38cbab37dafd](https://user-images.githubusercontent.com/23165606/148145094-e5025489-ed95-4315-a80b-9aca346bb31c.png)
