### PR TITLE
Add tally lights overlay powered by obs scene changes

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -116,6 +116,10 @@ io.on("connection", (socket) => {
         console.log("prod-join", clientName);
         socket.join(`prod:client-${clientName}`);
     });
+
+    socket.on("tally_change", ({ clientName, state, sceneName }) => {
+        socket.to(`prod:client-${clientName}`).emit("tally_change", { state, sceneName });
+    });
 });
 
 http.listen(port, () => {

--- a/website/src/components/broadcast/roots/TallyTransmitter.vue
+++ b/website/src/components/broadcast/roots/TallyTransmitter.vue
@@ -4,7 +4,8 @@ export default {
     props: ["client"],
     data: () => ({
         active: false,
-        visible: false
+        visible: false,
+        scene: ""
     }),
     computed: {
         state() {
@@ -20,18 +21,24 @@ export default {
 
     methods: {
         transmitState() {
-            this.$socket.client.emit("tally_change", { clientName: this.client.key, state: this.state, sceneName: this?.$root?.activeScene?.name });
+            this.$socket.client.emit("tally_change", { clientName: this.client.key, state: this.state, sceneName: this.scene });
         }
     },
     mounted() {
         window.addEventListener("obsSourceActiveChanged", (e) => {
             if (!this.client) return;
+            window.obsstudio?.getCurrentScene((scene) => {
+                this.scene = scene?.name;
+            });
             this.active = e.detail.active;
             this.transmitState();
         });
 
         window.addEventListener("obsSourceVisibleChanged", (e) => {
             if (!this.client) return;
+            window.obsstudio?.getCurrentScene((scene) => {
+                this.scene = scene?.name;
+            });
             this.visible = e.detail.visible;
             this.transmitState();
         });

--- a/website/src/components/broadcast/roots/TallyTransmitter.vue
+++ b/website/src/components/broadcast/roots/TallyTransmitter.vue
@@ -20,25 +20,29 @@ export default {
     },
 
     methods: {
-        transmitState() {
+        transmit() {
             this.$socket.client.emit("tally_change", { clientName: this.client.key, state: this.state, sceneName: this.scene });
+        },
+        transmitState() {
+            if (window.obsstudio) {
+                window.obsstudio.getCurrentScene((scene) => {
+                    this.scene = scene?.name;
+                    this.transmit();
+                });
+            } else {
+                this.transmit();
+            }
         }
     },
     mounted() {
         window.addEventListener("obsSourceActiveChanged", (e) => {
             if (!this.client) return;
-            window.obsstudio?.getCurrentScene((scene) => {
-                this.scene = scene?.name;
-            });
             this.active = e.detail.active;
             this.transmitState();
         });
 
         window.addEventListener("obsSourceVisibleChanged", (e) => {
             if (!this.client) return;
-            window.obsstudio?.getCurrentScene((scene) => {
-                this.scene = scene?.name;
-            });
             this.visible = e.detail.visible;
             this.transmitState();
         });

--- a/website/src/components/broadcast/roots/TallyTransmitter.vue
+++ b/website/src/components/broadcast/roots/TallyTransmitter.vue
@@ -1,8 +1,3 @@
-<template>
-  <div class="text-white">
-  </div>
-</template>
-
 <script>
 export default {
     name: "TallyTransmitter",

--- a/website/src/components/broadcast/roots/TallyTransmitter.vue
+++ b/website/src/components/broadcast/roots/TallyTransmitter.vue
@@ -1,0 +1,45 @@
+<template>
+  <div class="text-white">
+  </div>
+</template>
+
+<script>
+export default {
+    name: "TallyTransmitter",
+    props: ["client"],
+    data: () => ({
+        active: false,
+        visible: false
+    }),
+    computed: {
+        state() {
+            if (this.active && this.visible) {
+                return "active";
+            } else if (this.visible) {
+                return "preview";
+            } else {
+                return "inactive";
+            }
+        }
+    },
+
+    methods: {
+        transmitState() {
+            this.$socket.client.emit("tally_change", { clientName: this.client.key, state: this.state, sceneName: this?.$root?.activeScene?.name });
+        }
+    },
+    mounted() {
+        window.addEventListener("obsSourceActiveChanged", (e) => {
+            if (!this.client) return;
+            this.active = e.detail.active;
+            this.transmitState();
+        });
+
+        window.addEventListener("obsSourceVisibleChanged", (e) => {
+            if (!this.client) return;
+            this.visible = e.detail.visible;
+            this.transmitState();
+        });
+    }
+};
+</script>

--- a/website/src/components/broadcast/roots/TallyViewer.vue
+++ b/website/src/components/broadcast/roots/TallyViewer.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="tally-block" v-bind:class="{ preview: state === 'preview', active: state === 'active' }">
+    <div class="d-flex flex-column align-items-center">
+      <div class="state">
+        {{ state.toLocaleUpperCase() }}
+      </div>
+      <div class="metadata d-flex flex-column align-items-center">
+        <div>
+          {{ client.name }}
+        </div>
+        <div>
+          {{ sceneName }}
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+    name: "TallyViewer",
+    props: ["client"],
+    sockets: {
+        tally_change({ state, sceneName }) {
+            this.state = state;
+            this.sceneName = sceneName;
+        }
+    },
+    data: () => ({
+        state: "disconnected",
+        sceneName: "N/A"
+    })
+};
+</script>
+
+<style scoped>
+.tally-block {
+  height: 100vh;
+  width: 100vw;
+  background-color: #000000;
+  color: #ffffff;
+  display: grid;
+  place-items: center;
+  font-size: 5em;
+  transition: background-color 0.2s ease;
+  font-family: "Industry", "SLMN-Industry", sans-serif;
+}
+
+.state {
+  font-size: .75em;
+}
+
+.metadata {
+  font-size: .3em;
+}
+
+@media (min-width: 700px) {
+  .state {
+    font-size: 1.25em;
+  }
+
+  .metadata {
+    font-size: .75em;
+  }
+}
+
+
+.tally-block.preview {
+  background-color: #00ff00;
+  color: #000000;
+}
+
+.tally-block.active {
+  background-color: #ff0000;
+}
+</style>

--- a/website/src/components/broadcast/roots/TallyViewer.vue
+++ b/website/src/components/broadcast/roots/TallyViewer.vue
@@ -8,9 +8,6 @@
         <div>
           {{ client.name }}
         </div>
-        <div>
-          {{ sceneName }}
-        </div>
       </div>
     </div>
   </div>

--- a/website/src/router/broadcast.js
+++ b/website/src/router/broadcast.js
@@ -27,6 +27,8 @@ import StaffOverlay from "@/components/broadcast/roots/StaffOverlay";
 import CamsWrapper from "@/components/broadcast/cams/CamsWrapper";
 import SeasonHistoryOverlay from "@/components/broadcast/roots/SeasonHistoryOverlay";
 import IframeOverlay from "@/components/broadcast/roots/IframeOverlay";
+import TallyTransmitter from "@/components/broadcast/roots/TallyTransmitter";
+import TallyViewer from "@/components/broadcast/roots/TallyViewer";
 
 export default [
     { path: "ingame", component: IngameOverlay, props: route => ({ codes: route.query.codes }) },
@@ -51,6 +53,8 @@ export default [
     },
     { path: "break", component: BreakOverlay },
     { path: "syncer", component: SyncerOverlay },
+    { path: "tally-transmitter", component: TallyTransmitter },
+    { path: "tally-viewer", component: TallyViewer },
     { path: "break-bar", component: BreakBarOverlay },
     {
         path: "bracket",


### PR DESCRIPTION
- This adds a tally light system based on the OBS browser bindings
- Inside OBS a browser source with the url `/client/<clientname>/tally-transmitter` is added to scene of the corresponding observer's feed
- A viewer of the tally light visits `/client/<clientname>/tally-viewer`
- When the scene changes the OBS browser source notifies subscribed clients about the change

https://user-images.githubusercontent.com/23165606/148659135-db09be25-c833-4186-b501-d8d5ec92adcf.mp4

