### PR TITLE
Add count for matches worked on to player matches page

### DIFF
--- a/website/src/views/sub-views/PlayerMatches.vue
+++ b/website/src/views/sub-views/PlayerMatches.vue
@@ -5,7 +5,7 @@
                 <h6 class="d-flex matches-bar">Games: <a v-for="rel in mainPlayerRelationships" v-bind:key="rel.meta.singular_name" :href="'#' + convertToSlug(rel.meta.singular_name)">{{ rel.items.length }} as {{ rel.meta.singular_name }}</a></h6>
             </div>
             <div class="role-group" v-for="rel in mainPlayerRelationships" v-bind:key="rel.meta.singular_name">
-                <h1>as {{ rel.meta.singular_name }} ({{ rel.items.length }})</h1>
+                <h1 :id="convertToSlug(rel.meta.singular_name)">as {{ rel.meta.singular_name }} ({{ rel.items.length }})</h1>
                 <div class="row">
                     <Match class="col-12 col-sm-6 col-md-4 col-lg-3 mb-3"
                            v-for="item in rel.items"
@@ -74,6 +74,11 @@ export default {
                 if (groups[key] && groups[key].matches) groups[key].matches = groups[key].matches.sort(sortMatches);
             });
             return groups;
+        }
+    },
+    methods: {
+        convertToSlug(text) {
+            return text.toLowerCase().replace(/ /g, "-").replace(/[^\w-]+/g, "");
         }
     }
 };

--- a/website/src/views/sub-views/PlayerMatches.vue
+++ b/website/src/views/sub-views/PlayerMatches.vue
@@ -1,6 +1,9 @@
 <template>
     <div>
         <div class="container">
+            <div>
+                <h6 class="d-flex matches-bar">Games: <a v-for="rel in mainPlayerRelationships" v-bind:key="rel.meta.singular_name" :href="'#' + convertToSlug(rel.meta.singular_name)">{{ rel.items.length }} as {{ rel.meta.singular_name }}</a></h6>
+            </div>
             <div class="role-group" v-for="rel in mainPlayerRelationships" v-bind:key="rel.meta.singular_name">
                 <h1>as {{ rel.meta.singular_name }} ({{ rel.items.length }})</h1>
                 <div class="row">
@@ -77,5 +80,7 @@ export default {
 </script>
 
 <style scoped>
-
+    .matches-bar {
+        gap: 2rem;
+    }
 </style>


### PR DESCRIPTION
- Adds a bar above matches showing the number of each type of work done on a match
- Links that bring you further down the page to the section named
- Fix for [Issue #73](https://github.com/slmnio/slmngg-sfc/issues/73)

https://user-images.githubusercontent.com/87488710/148659727-66261c38-e01f-4f3c-89bd-292e1c841a97.mp4


