### PR TITLE
Add tally light links to detailed match page

### DIFF
--- a/website/src/components/website/LinkedPlayers.vue
+++ b/website/src/components/website/LinkedPlayers.vue
@@ -1,9 +1,9 @@
 <template>
     <span class="linked-players" v-if="html">
-        <router-link v-for="(player, i) in players" v-bind:key="player.id"
-                     :style="{order: i*2}" class="ct-active"
-                     :to="url('player', player)">{{ player.name }}<span v-if="player.verified">&nbsp;<i class="fas fa-badge-check" title="REAL"></i></span>
-        </router-link>
+        <span class="linked-player" v-for="(player, i) in players" v-bind:key="player.id" :style="{order: i*2}">
+            <router-link class="ct-active" :to="url('player', player)">{{ player.name }}<span v-if="player.verified">&nbsp;<i class="fas fa-badge-check" title="REAL"></i></span></router-link>
+            <router-link class="ct-active" v-if="showTally && player.clients && player.clients.length > 0 "  :to="`/client/${player.clients[0].key}/tally-viewer`"><i class="fas fa-tv" title="Tally"></i></router-link>
+        </span>
             <span v-for="i in parseInt(commas)" v-bind:key="i" :style="{order: (i*2)-1}">, </span>
             <span v-if="and" :style="{order: (players.length - 1) * 2 - 1}"> & </span>
     </span>
@@ -17,7 +17,16 @@ import LoadingIcon from "@/components/website/LoadingIcon";
 import { url } from "@/utils/content-utils";
 export default {
     name: "LinkedPlayers",
-    props: ["players"],
+    props: {
+        players: {
+            type: Array,
+            required: true
+        },
+        showTally: {
+            type: Boolean,
+            default: false
+        }
+    },
     methods: { url },
     components: { LoadingIcon },
     computed: {
@@ -43,6 +52,11 @@ export default {
     }
     .linked-players>* {
         white-space: pre;
+    }
+
+    .linked-player {
+        display: inline-flex;
+        gap: .25rem;
     }
 </style>
 

--- a/website/src/components/website/match/DetailedMatchStat.vue
+++ b/website/src/components/website/match/DetailedMatchStat.vue
@@ -4,13 +4,10 @@
         <div class="stat-b" v-if="raw" v-html="formattedTargetData"></div>
         <div class="stat-b" v-else-if="time">{{ prettyDate(targetData) }} local time</div>
         <div class="stat-b" v-else-if="players">
-            <LinkedPlayers :players="targetData" />
+            <LinkedPlayers :players="targetData" :show-tally="showTally" />
         </div>
         <div class="stat-b" v-else-if="externalLink">
             <a class="ct-active" :href="targetData" target="_blank">{{ targetData.replace('https://', '') }}</a>
-        </div>
-        <div class="stat-b" v-else-if="tallyLinks">
-            <router-link v-for="tallyClient in targetData" v-bind:key="tallyClient.id" :to="`/client/${tallyClient.key}/tally-viewer`">{{ tallyClient.name }}</router-link>
         </div>
         <div class="stat-b" v-else>{{ formattedTargetData }}</div>
     </div>
@@ -22,7 +19,7 @@ import spacetime from "spacetime";
 
 export default {
     name: "DetailedMatchStat",
-    props: ["match", "data", "override", "format", "raw", "time", "players", "externalLink", "tallyLinks"],
+    props: ["match", "data", "override", "format", "raw", "time", "players", "externalLink", "showTally"],
     components: { LinkedPlayers },
     methods: {
         prettyDate(timeString) {

--- a/website/src/components/website/match/DetailedMatchStat.vue
+++ b/website/src/components/website/match/DetailedMatchStat.vue
@@ -1,54 +1,37 @@
 <template>
-    <div class="stat mb-2" v-if="override || match[data]">
+    <div class="stat mb-2" v-if="targetData">
         <div class="stat-a"><slot></slot></div>
-        <div class="stat-b" v-if="time">{{ prettyDate(match[data], ' ') }} local time</div>
-        <div class="stat-b" v-else-if="raw" v-html="format ? format(match[data]) : match[data]"></div>
+        <div class="stat-b" v-if="raw" v-html="formattedTargetData"></div>
+        <div class="stat-b" v-else-if="time">{{ prettyDate(targetData) }} local time</div>
         <div class="stat-b" v-else-if="players">
-            <LinkedPlayers :players="match[data] || override" />
+            <LinkedPlayers :players="targetData" />
         </div>
-        <div class="stat-b" v-else-if="override">{{ format ? format(override) : override }}</div>
-        <div class="stat-b" v-else>{{ format ? format(match[data]) : match[data] }}</div>
-
+        <div class="stat-b" v-else-if="externalLink">
+            <a class="ct-active" :href="targetData" target="_blank">{{ targetData.replace('https://', '') }}</a>
+        </div>
+        <div class="stat-b" v-else>{{ formattedTargetData }}</div>
     </div>
 </template>
 
 <script>
 import LinkedPlayers from "@/components/website/LinkedPlayers";
+import spacetime from "spacetime";
 
 export default {
     name: "DetailedMatchStat",
-    props: ["data", "text", "format", "raw", "time", "override", "match", "players"],
+    props: ["match", "data", "override", "format", "raw", "time", "players", "externalLink"],
     components: { LinkedPlayers },
     methods: {
-        prettyDate: (tstr, split = "<br>") => {
-            if (!tstr) return "No time set";
-            const date = new Date(tstr);
-
-            let time = "";
-
-            if (date.getHours() >= 12) {
-                // pm
-                if (date.getHours() % 12 === 0) {
-                    time += 12;
-                } else {
-                    time += (date.getHours() % 12);
-                }
-                time += ":";
-                time += date.getMinutes().toString().padStart(2, "0");
-                time += "pm";
-            } else {
-                if (date.getHours() === 0) {
-                    time += 12;
-                } else {
-                    time += (date.getHours() % 12);
-                }
-                time += ":";
-                time += date.getMinutes().toString().padStart(2, "0");
-                time += "am";
-            }
-
-
-            return `${date.getDate()} ${("Jan.Feb.Mar.Apr.May.Jun.Jul.Aug.Sep.Oct.Nov.Dec".split("."))[date.getMonth()]}${split}${time}`;
+        prettyDate(timeString) {
+            return spacetime(timeString).goto(null).format("{date} {month-short} {time}");
+        }
+    },
+    computed: {
+        targetData() {
+            return this.override || this.match[this.data];
+        },
+        formattedTargetData() {
+            return this.format ? this.format(this.targetData) : this.targetData;
         }
     }
 };

--- a/website/src/components/website/match/DetailedMatchStat.vue
+++ b/website/src/components/website/match/DetailedMatchStat.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="stat mb-2" v-if="targetData">
+    <div class="stat mb-2" v-if="shouldShow">
         <div class="stat-a"><slot></slot></div>
         <div class="stat-b" v-if="raw" v-html="formattedTargetData"></div>
         <div class="stat-b" v-else-if="time">{{ prettyDate(targetData) }} local time</div>
@@ -8,6 +8,9 @@
         </div>
         <div class="stat-b" v-else-if="externalLink">
             <a class="ct-active" :href="targetData" target="_blank">{{ targetData.replace('https://', '') }}</a>
+        </div>
+        <div class="stat-b" v-else-if="tallyLinks">
+            <router-link v-for="tallyClient in targetData" v-bind:key="tallyClient.id" :to="`/client/${tallyClient.key}/tally-viewer`">{{ tallyClient.name }}</router-link>
         </div>
         <div class="stat-b" v-else>{{ formattedTargetData }}</div>
     </div>
@@ -19,7 +22,7 @@ import spacetime from "spacetime";
 
 export default {
     name: "DetailedMatchStat",
-    props: ["match", "data", "override", "format", "raw", "time", "players", "externalLink"],
+    props: ["match", "data", "override", "format", "raw", "time", "players", "externalLink", "tallyLinks"],
     components: { LinkedPlayers },
     methods: {
         prettyDate(timeString) {
@@ -29,6 +32,9 @@ export default {
     computed: {
         targetData() {
             return this.override || this.match[this.data];
+        },
+        shouldShow() {
+            return this.targetData && this.targetData?.length !== 0;
         },
         formattedTargetData() {
             return this.format ? this.format(this.targetData) : this.targetData;

--- a/website/src/views/DetailedMatch.vue
+++ b/website/src/views/DetailedMatch.vue
@@ -130,14 +130,13 @@
                     <stat :match="match" data="match_number">Match number</stat>
                     <stat :match="match" data="casters" :players="true">Casters</stat>
                     <stat :match="match" data="sub_event">Sub Event</stat>
-<!-- TODO: change this to spacetime -->
-                    <stat :match="match" data="start" time="true">Scheduled start time</stat>
-                    <stat :match="match" data="vod" :format="(e) => `<a class='ct-active' href='${e}' target='_blank'>${e.replace('https://', '')}</a>`" raw="true">VOD Link</stat>
-                    <stat :match="match" data="clean_feed" :format="(e) => `<a href='${e}' target='_blank'>${getURL(e).hostname}</a>`" raw="true">Clean Feed</stat>
+                    <stat :match="match" data="start" :time="true">Scheduled start time</stat>
+                    <stat :match="match" data="vod" :external-link="true">VOD Link</stat>
+                    <stat :match="match" data="clean_feed" :external-link="true">Clean Feed</stat>
                     <stat :match="match" data="first_to">First to</stat>
-                    <stat :match="match" v-for="relGroup in playerRelationshipGroups" v-bind:key="relGroup.meta.singular_name"
-                          :override="relGroup.items" :players="true">
-                        {{ relGroup.items.length === 1 ? relGroup.meta.singular_name : relGroup.meta.plural_name }}</stat>
+                    <stat :override="relGroup.items" v-for="relGroup in playerRelationshipGroups" v-bind:key="relGroup.meta.singular_name" :players="true">
+                        {{ relGroup.items.length === 1 ? relGroup.meta.singular_name : relGroup.meta.plural_name }}
+                    </stat>
                     <stat :match="match" data="replay_codes" :raw="true" :format="(t) => t[0].replace(/\n/g, '<br>')">Replay codes</stat>
                 </div>
             </div>

--- a/website/src/views/DetailedMatch.vue
+++ b/website/src/views/DetailedMatch.vue
@@ -134,10 +134,9 @@
                     <stat :match="match" data="vod" :external-link="true">VOD Link</stat>
                     <stat :match="match" data="clean_feed" :external-link="true">Clean Feed</stat>
                     <stat :match="match" data="first_to">First to</stat>
-                    <stat :override="relGroup.items" v-for="relGroup in playerRelationshipGroups" v-bind:key="relGroup.meta.singular_name" :players="true">
+                    <stat :override="relGroup.items" v-for="relGroup in playerRelationshipGroups" v-bind:key="relGroup.meta.singular_name" :players="true" :show-tally="relGroup.meta.singular_name === 'Observer'">
                         {{ relGroup.items.length === 1 ? relGroup.meta.singular_name : relGroup.meta.plural_name }}
                     </stat>
-                    <stat :override="observerClients" :tally-links="true">Tally Lights</stat>
                     <stat :match="match" data="replay_codes" :raw="true" :format="(t) => t[0].replace(/\n/g, '<br>')">Replay codes</stat>
                 </div>
             </div>
@@ -270,12 +269,6 @@ export default {
             if (groups[undefined]) return [];
 
             return Object.values(groups);
-        },
-        observerClients() {
-            if (!this.match?.player_relationships) return [];
-            return this.match?.player_relationships
-                .filter(rel => rel.singular_name === "Observer" && rel.player?.clients?.[0])
-                .map(rel => rel.player.clients[0]);
         }
     },
     metaInfo() {

--- a/website/src/views/DetailedMatch.vue
+++ b/website/src/views/DetailedMatch.vue
@@ -137,6 +137,7 @@
                     <stat :override="relGroup.items" v-for="relGroup in playerRelationshipGroups" v-bind:key="relGroup.meta.singular_name" :players="true">
                         {{ relGroup.items.length === 1 ? relGroup.meta.singular_name : relGroup.meta.plural_name }}
                     </stat>
+                    <stat :override="observerClients" :tally-links="true">Tally Lights</stat>
                     <stat :match="match" data="replay_codes" :raw="true" :format="(t) => t[0].replace(/\n/g, '<br>')">Replay codes</stat>
                 </div>
             </div>
@@ -239,7 +240,9 @@ export default {
                 }),
                 casters: ReactiveArray("casters"),
                 player_relationships: ReactiveArray("player_relationships", {
-                    player: ReactiveThing("player")
+                    player: ReactiveThing("player", {
+                        clients: ReactiveArray("clients")
+                    })
                 })
             });
         },
@@ -267,6 +270,12 @@ export default {
             if (groups[undefined]) return [];
 
             return Object.values(groups);
+        },
+        observerClients() {
+            if (!this.match?.player_relationships) return [];
+            return this.match?.player_relationships
+                .filter(rel => rel.singular_name === "Observer" && rel.player?.clients?.[0])
+                .map(rel => rel.player.clients[0]);
         }
     },
     metaInfo() {


### PR DESCRIPTION
I added the tally links of all observers for the current match to the detailed match page. I also refactored parts of the stat component.
![image](https://user-images.githubusercontent.com/23165606/150554093-43228214-5da2-4aa5-91c5-691a43f13c9e.png)
