### PR TITLE
Improvements to Tally Transmitter and Viewer

### DIFF
--- a/website/src/components/broadcast/roots/TallyViewer.vue
+++ b/website/src/components/broadcast/roots/TallyViewer.vue
@@ -25,10 +25,31 @@ export default {
             this.sceneName = sceneName;
         }
     },
+    methods: {
+        async getWakeLock() {
+            this.wakeLock = await navigator.wakeLock.request();
+            this.wakeLock.addEventListener("release", () => {
+                console.log("Screen Wake Lock released:", this.wakeLock.released);
+            });
+            console.log("Screen Wake Lock released:", this.wakeLock.released);
+        }
+    },
+    async mounted() {
+        if ("wakeLock" in navigator) {
+            // screen will stay on in supported browsers
+            await this.getWakeLock();
+            document.addEventListener("visibilitychange", async () => {
+                if (this.wakeLock !== null && document.visibilityState === "visible") {
+                    await this.getWakeLock();
+                }
+            });
+        }
+    },
     data: () => ({
         state: "disconnected",
         sceneName: "N/A",
-        number: null
+        number: null,
+        wakeLock: null
     })
 };
 </script>


### PR DESCRIPTION
If the `?num=<n>` parameter is provided to the tally transmitter the selected `/client/<client>` will be used to fetch the current match, get its observers and select the `<n>`'th observer in the list for transmission.

The Tally Viewer will now stay awake in [supported browsers](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API#browser_compatibility) using the [Wake Lock API](https://developer.mozilla.org/en-US/docs/Web/API/Screen_Wake_Lock_API).