### PR TITLE
Add a music player

### DIFF
--- a/server/src/airtable-interface.js
+++ b/server/src/airtable-interface.js
@@ -43,7 +43,7 @@ function setRebuilding(isRebuilding) {
 // Starting with syncing Matches
 
 // const tables = ["Matches", "Teams", "Themes", "Events", "Players", "Player Relationships"];
-const tables = ["Broadcasts", "Clients", "Teams", "Ad Reads", "Ad Read Groups", "Events", "Players", "Event Series", "News", "Matches",  "Themes",  "Socials", "Accolades", "Player Relationships", "Brackets", "Live Guests", "Headlines", "Maps", "Map Data", "Heroes", "Log Files", "Tracks", "Track Groups"];
+const tables = ["Broadcasts", "Clients", "Teams", "Ad Reads", "Ad Read Groups", "Events", "Players", "Event Series", "News", "Matches",  "Themes",  "Socials", "Accolades", "Player Relationships", "Brackets", "Live Guests", "Headlines", "Maps", "Map Data", "Heroes", "Log Files", "Tracks", "Track Groups", "Track Group Roles"];
 const staticTables = ["Redirects"];
 
 function deAirtable(obj) {

--- a/server/src/airtable-interface.js
+++ b/server/src/airtable-interface.js
@@ -43,7 +43,7 @@ function setRebuilding(isRebuilding) {
 // Starting with syncing Matches
 
 // const tables = ["Matches", "Teams", "Themes", "Events", "Players", "Player Relationships"];
-const tables = ["Broadcasts", "Clients", "Teams", "Ad Reads", "Ad Read Groups", "Events", "Players", "Event Series", "News", "Matches",  "Themes",  "Socials", "Accolades", "Player Relationships", "Brackets", "Live Guests", "Headlines", "Maps", "Map Data", "Heroes", "Log Files"];
+const tables = ["Broadcasts", "Clients", "Teams", "Ad Reads", "Ad Read Groups", "Events", "Players", "Event Series", "News", "Matches",  "Themes",  "Socials", "Accolades", "Player Relationships", "Brackets", "Live Guests", "Headlines", "Maps", "Map Data", "Heroes", "Log Files", "Tracks", "Track Groups"];
 const staticTables = ["Redirects"];
 
 function deAirtable(obj) {

--- a/website/package.json
+++ b/website/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "bootstrap-vue": "^2.21.2",
     "core-js": "^3.6.5",
+    "howler": "^2.2.3",
     "marked": "^2.1.3",
     "socket.io-client": "^4.0.1",
     "spacetime": "^6.16.0",

--- a/website/src/components/broadcast/roots/MusicOverlay.vue
+++ b/website/src/components/broadcast/roots/MusicOverlay.vue
@@ -1,0 +1,191 @@
+<template>
+    <div class="song-holder">
+        <transition name="song" mode="out-in">
+            <div v-if="mainPlayer" class="song-title industry-align">
+                <i class="fas fa-music"></i>
+                {{ mainPlayer.title }}
+            </div>
+        </transition>
+    </div>
+</template>
+
+<script>
+import { ReactiveArray, ReactiveRoot } from "@/utils/reactive";
+
+class Track {
+    constructor(trackData) {
+        this.title = trackData?.title;
+        this.artist = trackData?.artist;
+        this.id = trackData?.id;
+        this.audio = new Audio(trackData?.file?.[0]?.url);
+        this.currentTime = this.audio.currentTime;
+        this.duration = this.audio.duration;
+    }
+
+    play(startingVolume) {
+        this.audio.volume = startingVolume;
+        this.audio.play();
+        this.audio.addEventListener("timeupdate", (e) => {
+            this.currentTime = e.target.currentTime;
+            this.duration = e.target.duration;
+        });
+    }
+
+    pause() {
+        this.audio.pause();
+    }
+
+    rampVolume(targetVolume, duration) {
+        const climbAmount = (targetVolume - this.audio.volume) / (duration * 10);
+
+        console.log(`${this.id} - ${this.title}: climbing to ${targetVolume} at ${climbAmount}p`);
+
+        const interval = setInterval(() => {
+            if (this.audio.volume + climbAmount >= 1) {
+                this.audio.volume = 1;
+            } else if (this.audio.volume + climbAmount <= 0) {
+                this.audio.volume = 0;
+            } else {
+                this.audio.volume += climbAmount;
+            }
+            if (this.audio.volume === targetVolume) {
+                clearInterval(interval);
+                this.audio.volume = targetVolume;
+            }
+
+            if (climbAmount > 0 && this.audio.volume >= targetVolume) {
+                // climbing up & over
+                clearInterval(interval);
+                this.audio.volume = targetVolume;
+            }
+            if (climbAmount < 0 && this.audio.volume <= targetVolume) {
+                // climbing down and under
+                clearInterval(interval);
+                this.audio.volume = targetVolume;
+            }
+        }, 100);
+        setTimeout(() => {
+            clearInterval(interval);
+        }, (duration + 1) * 1000);
+    }
+}
+
+
+export default {
+    name: "MusicOverlay",
+    props: ["broadcast", "break"],
+    data: () => ({
+        started: false,
+        mainPlayer: null,
+        crossfadePlayer: null,
+        intervals: {
+            main: null
+        },
+        crossfading: false,
+        crossfadeDuration: 10, // seconds
+        volume: 0.2,
+        playedTrackIds: []
+    }),
+    computed: {
+        tracksData() {
+            return ReactiveRoot(this.broadcast.id, {
+                caster_tracks: ReactiveArray("caster_tracks", {
+                    tracks: ReactiveArray("tracks")
+                }),
+                break_tracks: ReactiveArray("break_tracks", {
+                    tracks: ReactiveArray("tracks")
+                })
+            });
+        },
+        trackList() {
+            return this.break ? this.tracksData?.break_tracks?.flatMap(tl => tl?.tracks).filter(tl => tl) : this.tracksData?.caster_tracks?.flatMap(tl => tl?.tracks).filter(tl => tl);
+        },
+        unplayedTracks() {
+            return this.trackList?.filter(t => t && !this.playedTrackIds.includes(t?.id));
+        },
+        loaded() {
+            if (!this.trackList) return false;
+            if (this.trackList?.length === 0) return false;
+            return !this.trackList?.some(t => t.__loading);
+        }
+    },
+    watch: {
+        loaded(loaded) {
+            if (loaded && !this.started) {
+                this.start();
+            }
+        },
+        mainPlayer: {
+            deep: true,
+            handler(p) {
+                if (p.duration - p.currentTime < this.crossfadeDuration) {
+                    this.startCrossfade();
+                }
+            }
+        }
+    },
+    methods: {
+        getNextTrack() {
+            if (this.unplayedTracks.length === 0) {
+                this.playedTrackIds = [this.mainPlayer.id];
+            }
+            const nextTrack = this.unplayedTracks[Math.floor(this.unplayedTracks.length * Math.random())];
+            this.playedTrackIds.push(nextTrack.id);
+            return nextTrack;
+        },
+        start() {
+            this.started = true;
+            const next = this.getNextTrack();
+            this.mainPlayer = new Track(next);
+            this.mainPlayer.play(this.volume);
+        },
+        startCrossfade() {
+            if (this.crossfading || this.crossfadePlayer) return;
+            console.log(`${this.mainPlayer.id} - ${this.mainPlayer.title}: Crossfading (${this.crossfadeDuration}s)`);
+            this.crossfading = true;
+            const next = this.getNextTrack();
+
+            this.crossfadePlayer = new Track(next);
+            this.crossfadePlayer.play(0);
+
+            this.mainPlayer.rampVolume(0, this.crossfadeDuration);
+            this.crossfadePlayer.rampVolume(this.volume, this.crossfadeDuration);
+
+            setTimeout(() => {
+                console.log("Crossfade at middle point, players are swapped");
+                [this.mainPlayer, this.crossfadePlayer] = [this.crossfadePlayer, this.mainPlayer];
+            }, this.crossfadeDuration * 500);
+
+            setTimeout(() => {
+                console.log("Crossfade finished, ending old player");
+                this.crossfading = false;
+                this.crossfadePlayer.pause();
+                this.crossfadePlayer = null;
+            }, this.crossfadeDuration * 1000);
+        }
+    }
+};
+
+</script>
+
+<style scoped>
+
+
+.song-enter-active, .song-leave-active {
+    transition: all 400ms ease;
+    position: absolute;
+    left: 0;
+    bottom: 0;
+}
+
+.song-enter, .song-leave-to {
+    opacity: 0;
+}
+
+.fa-music {
+    height: 1em;
+    fill: currentColor;
+    margin-right: .5em;
+}
+
+</style>

--- a/website/src/components/broadcast/roots/MusicOverlay.vue
+++ b/website/src/components/broadcast/roots/MusicOverlay.vue
@@ -47,8 +47,8 @@ class Track {
         clearInterval(this.interval);
     }
 
-    rampVolume(targetVolume, duration) {
-        this.audio.fade(this.audio.volume(), targetVolume, duration * 1000);
+    rampVolume(startingVolume, targetVolume, duration) {
+        this.audio.fade(startingVolume, targetVolume, duration * 1000);
     }
 }
 
@@ -161,8 +161,8 @@ export default {
             this.crossfadePlayer = new Track(next);
             this.crossfadePlayer.play(0);
 
-            this.mainPlayer.rampVolume(0, this.crossfadeDuration);
-            this.crossfadePlayer.rampVolume(this.volume, this.crossfadeDuration);
+            this.mainPlayer.rampVolume(this.volume, 0, this.crossfadeDuration);
+            this.crossfadePlayer.rampVolume(0, this.volume, this.crossfadeDuration);
 
             setTimeout(() => {
                 console.log("Crossfade at middle point, players are swapped");

--- a/website/src/components/broadcast/roots/MusicOverlay.vue
+++ b/website/src/components/broadcast/roots/MusicOverlay.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="song-holder">
         <transition name="song" mode="out-in">
-            <div v-if="mainPlayer && showTitle" class="song-title industry-align" v-show="visible">
+            <div v-if="mainPlayer && showTitle && visible" class="song-title industry-align">
                 <i class="fas fa-music song-icon"></i>
                 <transition name="song" mode="out-in">
                     <span class="song-text" :key="mainPlayer.title">

--- a/website/src/router/broadcast.js
+++ b/website/src/router/broadcast.js
@@ -125,5 +125,5 @@ export default [
     { path: "overview", component: OverviewOverlay },
     { path: "media", component: MediaOverlay },
     { path: "clock", component: MediaClock },
-    { path: "music", component: MusicOverlay, props: route => ({ break: route.query.break }) }
+    { path: "music", component: MusicOverlay, props: route => ({ break: route.query.break, showTitle: ["showTitle", "showText", "text", "title", "song"].some(t => route.query[t]) }) }
 ];

--- a/website/src/router/broadcast.js
+++ b/website/src/router/broadcast.js
@@ -35,6 +35,7 @@ import MediaOverlay from "@/components/broadcast/roots/MediaOverlay";
 import MediaClock from "@/components/broadcast/roots/MediaClock";
 import FullCamOverlay from "@/components/broadcast/cams/FullCamOverlay";
 import CasterBackground from "@/components/broadcast/CasterBackground";
+import MusicOverlay from "@/components/broadcast/roots/MusicOverlay";
 
 export default [
     { path: "ingame", component: IngameOverlay, props: route => ({ codes: route.query.codes }) },
@@ -123,5 +124,6 @@ export default [
     { path: "player-history", component: PlayerHistory, props: route => ({ showMinor: route.query.minor }) },
     { path: "overview", component: OverviewOverlay },
     { path: "media", component: MediaOverlay },
-    { path: "clock", component: MediaClock }
+    { path: "clock", component: MediaClock },
+    { path: "music", component: MusicOverlay, props: route => ({ break: route.query.break }) }
 ];

--- a/website/src/router/broadcast.js
+++ b/website/src/router/broadcast.js
@@ -125,5 +125,14 @@ export default [
     { path: "overview", component: OverviewOverlay },
     { path: "media", component: MediaOverlay },
     { path: "clock", component: MediaClock },
-    { path: "music", component: MusicOverlay, props: route => ({ break: route.query.break, showTitle: ["showTitle", "showText", "text", "title", "song"].some(t => route.query[t]) }) }
+    {
+        path: "music",
+        component: MusicOverlay,
+        props: route => ({
+            role: route.query.group || route.query.role,
+            showTitle: ["showTitle", "showText", "text", "title", "song"].some(t => route.query[t]),
+            volume: parseFloat(route.query.volume) || 0.2,
+            crossfadeDuration: parseFloat(route.query.crossfade || route.query.fade) || 10
+        })
+    }
 ];

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -4733,6 +4733,11 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
   integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
 
+howler@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/howler/-/howler-2.2.3.tgz#a2eff9b08b586798e7a2ee17a602a90df28715da"
+  integrity sha512-QM0FFkw0LRX1PR8pNzJVAY25JhIWvbKMBFM4gqk+QdV+kPXOhleWGCB6AiAF/goGjIHK2e/nIElplvjQwhr0jg==
+
 hpack.js@^2.1.6:
   version "2.1.6"
   resolved "https://registry.yarnpkg.com/hpack.js/-/hpack.js-2.1.6.tgz#87774c0949e513f42e84575b3c45681fade2a0b2"


### PR DESCRIPTION
This PR ports the old music player into SLMN.gg.
- Song data is moved into airtable for quick editing
- Lists of songs are connected to airtable which means that changing a client's broadcast will automatically update the music as well
- Songs can be added to track groups, these groups can be given roles (for example caster bg, break), these groups can then be selected using the `group=<group>` URL parameter