### PR TITLE
Use ES Modules for the data server

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
   },
   "homepage": "https://github.com/slmnio/slmngg-server#readme",
   "private": true,
+  "type": "module",
   "devDependencies": {
     "eslint": "^7.23.0",
     "nodemon": "^2.0.7"
@@ -24,7 +25,7 @@
     "chalk": "^4.1.0",
     "cors": "^2.8.5",
     "discord.js": "v13",
-    "dotenv": "^8.2.0",
+    "dotenv": "^16.0.0",
     "express": "^4.17.1",
     "node-fetch": "^2.6.1",
     "ora": "^5.4.0",

--- a/server/src/airtable-interface.js
+++ b/server/src/airtable-interface.js
@@ -1,10 +1,14 @@
-const Airtable = require("airtable");
-const airtable = new Airtable({ apiKey: process.env.AIRTABLE_KEY });
-const Cache = require("./cache.js");
-const slmngg = airtable.base(process.env.AIRTABLE_APP);
-const ora = require("ora");
-const chalk = require("chalk");
+import Airtable from "airtable";
+import * as Cache from "./cache.js";
+import ora from "ora";
+import chalk from "chalk";
 
+import customTableUpdate from "./custom-datasets.js";
+
+import { log } from "./discord/slmngg-log.js";
+
+const airtable = new Airtable({ apiKey: process.env.AIRTABLE_KEY });
+const slmngg = airtable.base(process.env.AIRTABLE_APP);
 // const st4 = require("./st4")(airtable);
 
 const logUpdates = false;
@@ -16,7 +20,7 @@ const logUpdates = false;
 let io = null;
 let _isRebuilding = true;
 let _rebuildStart = null;
-function setup(_io) {
+export function setup(_io) {
     io = _io;
 
     console.log("[rebuild] rebuilding...");
@@ -108,8 +112,6 @@ async function processTableData(tableName, data, linkRecords = false) {
     customTableUpdate(tableName, Cache);
 }
 
-const customTableUpdate = require("./custom-datasets");
-const { log } = require("./discord/slmngg-log");
 
 function registerUpdater(tableName, options) {
     let pollRate = 3000;
@@ -177,12 +179,9 @@ async function sync() {
 sync();
 // setInterval(sync, 5 * 1000);
 
-module.exports = {
-    async update(table, id, data) {
-        return await slmngg(table).update(id, data);
-    },
-    async select(table, filter) {
-        return await slmngg(table).select(filter).all();
-    },
-    setup
-};
+export async function update(table, id, data) {
+    return await slmngg(table).update(id, data);
+}
+export async function select(table, filter) {
+    return await slmngg(table).select(filter).all();
+}

--- a/server/src/api/EventHandler.js
+++ b/server/src/api/EventHandler.js
@@ -1,6 +1,4 @@
-const { handle } = require("express/lib/router");
-
-class EventHandler {
+export class EventHandler {
     constructor(props) {
         this.fns = [];
     }
@@ -14,7 +12,7 @@ class EventHandler {
     }
 }
 
-class DistributedEventHandler {
+export class DistributedEventHandler {
     constructor(props) {
         this.handlers = {};
     }
@@ -32,4 +30,3 @@ class DistributedEventHandler {
     }
 }
 
-module.exports = { EventHandler, DistributedEventHandler };

--- a/server/src/cache.js
+++ b/server/src/cache.js
@@ -26,7 +26,7 @@ function getAntiLeakIDs() {
  */
 let io = null;
 
-function setup(_io) {
+export function setup(_io) {
     io = _io;
     return this;
 }
@@ -38,7 +38,7 @@ async function broadcast(room, command, ...data) {
 }
 
 let updateFunctions = [];
-function onUpdate(fn) {
+export function onUpdate(fn) {
     updateFunctions.push(fn);
 }
 
@@ -78,7 +78,7 @@ const longTextMap = {
     "News": ["content"]
 };
 
-async function set(id, data, options) {
+export async function set(id, data, options) {
 
     if (data?.__tableName) {
         // Airtable bug where long textboxes that are cleared are just "\n" (and is not falsy)
@@ -136,7 +136,7 @@ function cleanID(id) {
     if (id.startsWith("rec") && id.length === 17) id = id.slice(3);
     return id;
 }
-async function get(id) {
+export async function get(id) {
     id = cleanID(id);
     let data = store.get(id);
     if (data) data = await removeAntiLeak(id, data);
@@ -147,6 +147,3 @@ async function get(id) {
 }
 
 
-module.exports = {
-    set, get, setup, onUpdate
-};

--- a/server/src/custom-datasets.js
+++ b/server/src/custom-datasets.js
@@ -2,12 +2,11 @@
 * Functions to create custom datasets as we load data
 * */
 
-function tableUpdated(tableName, Cache) {
+export default function tableUpdated(tableName, Cache) {
     if (tableName === "Matches") matchUpdate(Cache);
     if (tableName === "Broadcasts") broadcastUpdate(Cache);
     if (tableName === "Players") playerList(Cache);
 }
-module.exports = tableUpdated;
 
 async function matchUpdate(Cache) {
     let allMatches = await Cache.get("Matches");

--- a/server/src/discord/auction.js
+++ b/server/src/discord/auction.js
@@ -1,6 +1,7 @@
-const creds = require("../config/creds.json");
-const Airtable = require("airtable");
-const Discord = require("discord.js");
+import creds from "../config/creds.json";
+import Airtable from "airtable";
+import Discord from "discord.js";
+
 const at = new Airtable({apiKey: creds.airtable.key});
 
 const balances = {};

--- a/server/src/discord/client.js
+++ b/server/src/discord/client.js
@@ -1,4 +1,4 @@
-const { Client, Intents, Permissions } = require("discord.js");
+import { Client, Intents, Permissions } from "discord.js";
 
 let client = null;
 
@@ -11,4 +11,4 @@ if (process.env.DISCORD_TOKEN) {
     client.once("ready", () => console.log(`[discord] Logged in as ${client.user.tag}`));
 }
 
-module.exports = client;
+export default client;

--- a/server/src/discord/managers.js
+++ b/server/src/discord/managers.js
@@ -1,4 +1,4 @@
-class MapHandler {
+export class MapHandler {
     constructor({ map, ids, event, create_function }) {
         // console.log("Map constructor", {map, ids});
         this.map = new MapObject(map, true);
@@ -22,7 +22,7 @@ class MapHandler {
     }
 }
 
-class MapObject {
+export class MapObject {
     constructor(text, arrays=false) {
         this.arrays = arrays;
         this.data = (text || "").split("\n").map(e => {
@@ -64,4 +64,3 @@ class MapObject {
     }
 }
 
-module.exports = { MapHandler, MapObject };

--- a/server/src/discord/new_auction.js
+++ b/server/src/discord/new_auction.js
@@ -1,7 +1,6 @@
-const client = require("./client.js");
-const Cache = require("../cache.js");
-const { update, select } = require("../airtable-interface.js");
-const Discord = require("discord.js");
+import client from "./client.js";
+import { select, update } from "../airtable-interface.js";
+import Discord from "discord.js";
 
 let io;
 
@@ -388,7 +387,7 @@ client.on("messageCreate", async message => {
     if (c) c.execute(args, message);
 });
 
-module.exports = (_io) => {
+export default (_io) => {
     io = {
         emit: (...a) => {
             console.log("socket emit", a);

--- a/server/src/discord/slmngg-log.js
+++ b/server/src/discord/slmngg-log.js
@@ -1,4 +1,4 @@
-const client = require("./client.js");
+import client from "./client.js";
 
 async function getChannel() {
     if (!process.env.SLMNGG_LOGS_GUILD_ID) return null;
@@ -13,14 +13,10 @@ async function getChannel() {
     return channel;
 }
 
-async function log(text) {
+export async function log(text) {
     console.log("[Log]", text);
     if (!client) return;
     let channel = await getChannel();
     if (!channel) return;
     return channel.send(text);
 }
-
-module.exports = {
-    log
-};

--- a/server/src/discord/staff.js
+++ b/server/src/discord/staff.js
@@ -1,13 +1,14 @@
 /* BPL Staff Automation */
 
-const client = require("./client.js");
-const Airtable = require("airtable");
-const { MessageEmbed, Permissions } = require("discord.js");
+import client from "./client.js";
+import Airtable from "airtable";
+import { MapHandler } from "./managers.js";
+import { log } from "./slmngg-log.js";
+import { MessageEmbed, Permissions } from "discord.js";
+
 const airtable = new Airtable({apiKey: process.env.AIRTABLE_KEY});
 const base = airtable.base("appQd7DO7rDiMUIEj");
 
-const { MapHandler } = require("./managers.js");
-const { log } = require("./slmngg-log.js");
 
 function deAirtable(obj) {
     const data = {};

--- a/server/src/images.js
+++ b/server/src/images.js
@@ -1,8 +1,8 @@
-const sharp = require("sharp");
-const fp = require("fs/promises");
-const fs = require("fs");
-const path = require("path");
-const https = require("https");
+import sharp from "sharp";
+import fp from "fs/promises";
+import fs from "fs";
+import path from "path";
+import https from "https";
 
 const heldPromises = [];
 function getHeldPromise(parts) {
@@ -21,7 +21,7 @@ async function heldPromise(parts, promise) {
 }
 
 function getPath(filename, size) {
-    return path.join(__dirname, "..", "images", size, filename);
+    return path.join(path.resolve("."), "images", size, filename);
 }
 
 async function getImage(filename, size) {
@@ -126,7 +126,7 @@ async function fullGetURL(url, sizeText, sizeData) {
     return await getImage(filename, sizeText);
 }
 
-module.exports = ({ app, cors, Cache }) => {
+export default ({ app, cors, Cache }) => {
 
     ensureFolder("orig").then(r => console.log("[images] orig folder ensured"));
 

--- a/server/src/meta.js
+++ b/server/src/meta.js
@@ -1,4 +1,4 @@
-require("dotenv").config();
+import "dotenv/config";
 function cleanID(id) {
     if (!id) return null;
     if (typeof id !== "string") return id.id || null; // no real id oops
@@ -65,7 +65,7 @@ function niceJoin(array) {
     return array[0];
 }
 
-module.exports = ({ app, Cache }) => {
+export default ({ app, Cache }) => {
 
     async function subArrayNames(ids) {
         if (!ids?.length) return [];

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -13,7 +13,7 @@ function niceJoin(array) {
     return array[0];
 }
 
-module.exports = ({ app, cors, Cache, io }) => {
+export default ({ app, cors, Cache, io }) => {
     app.get("/redirect", async (req, res) => {
         try {
             let redirects = (await Cache.get("Redirects"))?.items;

--- a/server/src/st4.js
+++ b/server/src/st4.js
@@ -6,7 +6,7 @@
 * 3) Update the ST4 Airtable records with how the process went.
 * */
 
-module.exports = function(airtable) {
+export default function(airtable) {
 
     const bases = {
         st4: airtable.base("appauIFW019nLZJ5t"),
@@ -120,6 +120,4 @@ module.exports = function(airtable) {
         if (!player) return;
         await processPlayer(player);
     }, 3000);
-
-
-};
+}


### PR DESCRIPTION
- Set the data server package to be of type module
- Move all `require` imports to `import`
- Move all `module.exports` to `export` and `export default`
This is nicer because it enables new module-only features like top level await and also has nicer syntax.
I haven't been able to test all code because some of it relies on Discord