### PR TITLE
Add heartbeat to tally lights

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -122,9 +122,13 @@ io.on("connection", (socket) => {
         socket.join(`prod:client-${clientName}`);
     });
 
-    socket.on("tally_change", ({ clientName, state, number, sceneName, data }) => {
+    socket.on("tally_change", ({ clientName, state, number, sceneName }) => {
         // console.log("[tally]", clientName, state, number, data);
         socket.to(`prod:client-${clientName}`).emit("tally_change", { state, number, sceneName });
+    });
+
+    socket.on("tally_heartbeat", ({ clientName, number }) => {
+        socket.to(`prod:client-${clientName}`).emit("tally_heartbeat", { number });
     });
 
     socket.on("media_update", (status, value) => {

--- a/website/src/components/broadcast/roots/TallyTransmitter.vue
+++ b/website/src/components/broadcast/roots/TallyTransmitter.vue
@@ -7,7 +7,8 @@ export default {
     data: () => ({
         active: false,
         visible: false,
-        scene: ""
+        scene: "",
+        heartbeatInterval: null
     }),
     computed: {
         state() {
@@ -61,6 +62,12 @@ export default {
             } else {
                 this.transmit();
             }
+        },
+        heartbeat() {
+            this.$socket.client.emit("tally_heartbeat", {
+                clientName: this.observer,
+                number: this.number
+            });
         }
     },
     mounted() {
@@ -75,6 +82,11 @@ export default {
             this.visible = e.detail.visible;
             this.transmitState();
         });
+
+        this.heartbeatInterval = setInterval(() => {
+            if (!this.observer) return;
+            this.heartbeat();
+        }, 1000);
     }
 };
 </script>

--- a/website/src/components/broadcast/roots/TallyViewer.vue
+++ b/website/src/components/broadcast/roots/TallyViewer.vue
@@ -23,6 +23,12 @@ export default {
             this.state = state;
             this.number = number;
             this.sceneName = sceneName;
+        },
+        tally_heartbeat({ number }) {
+            this.number = number;
+            if (this.state === "disconnected") {
+                this.state = "connected";
+            }
         }
     },
     methods: {


### PR DESCRIPTION
Now tally transmitters send a heartbeat even when they get no data from obs. This means that people viewing tally lights can still see that they are set up correctly even before the correct scene is selected.