### PR TITLE
add new airtable cdn domain to allowlist

### DIFF
--- a/server/src/images.js
+++ b/server/src/images.js
@@ -194,7 +194,7 @@ module.exports = ({ app, cors, Cache, corsHandle }) => {
                 };
             }
 
-            if (["svg", "gif"].includes(originalFileType)) {
+            if (!size /*["svg", "gif"].includes(originalFileType)*/) { // TODO: load image first then detect filetype
                 // just do orig if svg
                 size = "orig";
             }
@@ -205,7 +205,11 @@ module.exports = ({ app, cors, Cache, corsHandle }) => {
 
             let imagePath = await getImage(filename, size);
 
-            if (imagePath) return res.sendFile(imagePath);
+            if (imagePath) {
+                // let metaFileType = (await sharp(imagePath).metadata())?.format;
+                // console.log({metaFileType});
+                return res.sendFile(imagePath);
+            }
             console.log("[image]", `no file for ${originalFilename} @ ${size}`);
             // no image
 
@@ -221,6 +225,9 @@ module.exports = ({ app, cors, Cache, corsHandle }) => {
                 orig = await getImage(filename, "orig");
                 if (size === "orig") return res.sendFile(orig);
             }
+
+            // let metaFileType = (await sharp(orig).metadata())?.format;
+            // console.log({metaFileType});
 
             // resize time!
             // console.log("[image]", `resizing ${originalFilename} @ ${size}`);

--- a/server/src/images.js
+++ b/server/src/images.js
@@ -148,7 +148,7 @@ module.exports = ({ app, cors, Cache, corsHandle }) => {
             const originalFileType = dots[dots.length - 1]; // last . (now works with .svg.png)
             const filename = parts[4] + "." + originalFileType;
 
-            if (!["dl.airtable.com", "media.slmn.io"].some(domain => domain === parts[2])) {
+            if (!["dl.airtable.com", "media.slmn.io", "v5.airtableusercontent.com"].some(domain => domain === parts[2])) {
                 return res.status(400).send("Domain not whitelisted");
             }
 


### PR DESCRIPTION
This is a temporary, basically untested mitigation for issue #149, though I have no idea how it will react to Airtable's new URL expiration. I also expect GIFs to break again, as Airtable's new URL schema doesn't share file extensions anymore.