### PR TITLE
Reimplement the copy token ui 

### DIFF
--- a/website/src/components/website/LoggedInUser.vue
+++ b/website/src/components/website/LoggedInUser.vue
@@ -6,20 +6,28 @@
         </template>
         <b-dropdown-item variant="dark" :to="url('player', { id: playerID })" active-class="active">Player page</b-dropdown-item>
         <b-dropdown-item variant="dark" :href="rootLinkExternal('/profile')" :to="rootLinkRouter('/profile')" active-class="active">Edit profile</b-dropdown-item>
+        <b-dropdown-divider v-if="isProduction"></b-dropdown-divider>
         <b-dropdown-item v-if="isProduction" variant="dark" :href="rootLinkExternal('/dashboard')" :to="rootLinkRouter('/dashboard')" active-class="active">Dashboard</b-dropdown-item>
+        <b-dropdown-item v-if="isProduction" variant="dark" v-b-modal.token-modal>Token</b-dropdown-item>
+        <TokenModal />
     </b-nav-item-dropdown>
 </template>
 
 <script>
 import { url } from "@/utils/content-utils.js";
-import { BDropdownItem, BNavItemDropdown } from "bootstrap-vue";
+import { BDropdownDivider, BDropdownItem, BNavItemDropdown, VBModal } from "bootstrap-vue";
 import { isAuthenticated, isOnMainDomain } from "@/utils/auth";
 import { getMainDomain } from "@/utils/fetch";
+import TokenModal from "@/components/website/dashboard/TokenModal.vue";
 
 export default {
     name: "LoggedInUser",
+    directives: { BModal: VBModal },
     components: {
-        BDropdownItem, BNavItemDropdown
+        TokenModal,
+        BDropdownItem,
+        BNavItemDropdown,
+        BDropdownDivider
     },
     computed: {
         user() {

--- a/website/src/components/website/dashboard/TokenModal.vue
+++ b/website/src/components/website/dashboard/TokenModal.vue
@@ -1,31 +1,24 @@
 <template>
-    <div>
-        <div class="mt-2" v-b-modal.token>
-            <b-button>
-                <i class="fas fa-fw fa-lock"></i> Token
-            </b-button>
-        </div>
-        <b-modal hide-footer ref="modal" id="token" title="SLMN.gg Token">
-            <p>Your <b>SLMN.GG token</b> is used to identify you and perform requests on the site.</p>
-            <p>You can use the token in our Companion module to make full use of the buttons.</p>
+    <b-modal hide-footer id="token-modal" title="SLMN.gg Token">
+        <p>Your <b>SLMN.GG token</b> is used to identify you and perform requests on the site.</p>
+        <p>You can use the token in our Companion module to make full use of the buttons.</p>
 
-            <p><b>Please note:</b> Your token gives anyone who has it <b class="text-danger">full access to your account</b> on SLMN.GG, including any permissions you have to edit matches or broadcasts.</p>
-            <p>You shouldn't share it with a third party. Only use it in programs you are running yourself.</p>
+        <p><b>Please note:</b> Your token gives anyone who has it <b class="text-danger">full access to your account</b> on SLMN.GG, including any permissions you have to edit matches or broadcasts.</p>
+        <p>You shouldn't share it with a third party. Only use it in programs you are running yourself.</p>
 
-            <b-form-checkbox v-model="hasAccepted">
-                I will keep my token safe
-            </b-form-checkbox>
+        <b-form-checkbox v-model="hasAccepted">
+            I will keep my token safe
+        </b-form-checkbox>
 
-            <b-button v-if="token" class="mt-3" @click="copyToken" :disabled="!hasAccepted">
-                <i :class="`fas fa-fw ${recentlyCopied ? 'fa-clipboard-check' : 'fa-copy'}`"></i> Copy token
-            </b-button>
-            <p class="mt-3" v-else>
-                <i class="fas fa-exclamation-triangle mr-2"></i> You are not logged in.
-            </p>
+        <b-button v-if="token" class="mt-3" @click="copyToken" :disabled="!hasAccepted">
+            <i :class="`fas fa-fw ${recentlyCopied ? 'fa-clipboard-check' : 'fa-copy'}`"></i> Copy token
+        </b-button>
+        <p class="mt-3" v-else>
+            <i class="fas fa-exclamation-triangle mr-2"></i> You are not logged in.
+        </p>
 
 
-        </b-modal>
-    </div>
+    </b-modal>
 </template>
 
 

--- a/website/src/components/website/dashboard/TokenModal.vue
+++ b/website/src/components/website/dashboard/TokenModal.vue
@@ -1,0 +1,66 @@
+<template>
+    <div>
+        <div class="mt-2" v-b-modal.token>
+            <b-button>
+                <i class="fas fa-fw fa-lock"></i> Token
+            </b-button>
+        </div>
+        <b-modal hide-footer ref="modal" id="token" title="SLMN.gg Token">
+            <p>
+                This token can be used for our Companion module or while using the API in another way.<br>
+            </p>
+
+            <p>
+                The token gives <strong>full access to SLMN.gg</strong> so you <strong>must keep it safe</strong>.
+            </p>
+
+            <b-form-checkbox v-model="hasAccepted">
+                I will keep my token safe
+            </b-form-checkbox>
+
+            <b-button v-if="token" class="mt-2" @click="copyToken" :disabled="!hasAccepted">
+                <i :class="`fas fa-fw ${recentlyCopied ? 'fa-clipboard-check' : 'fa-copy'}`"></i> Copy token
+            </b-button>
+
+            <p class="mt-2" v-else>
+                <i class="fas fa-exclamation-triangle mr-2"></i> You are not logged in.
+            </p>
+
+
+        </b-modal>
+    </div>
+</template>
+
+
+<script>
+import { BButton, BModal, VBModal, BFormCheckbox } from "bootstrap-vue";
+
+export default {
+    name: "TokenModal",
+    components: { BModal, BButton, BFormCheckbox },
+    directives: { BModal: VBModal },
+    props: {
+        broadcast: Object
+    },
+    data: () => ({
+        hasAccepted: false,
+        recentlyCopied: false
+    }),
+    computed: {
+        token() {
+            return this.$root.auth.token;
+        }
+    },
+    methods: {
+        copyToken() {
+            navigator.clipboard.writeText(this.token);
+            this.recentlyCopied = true;
+            setTimeout(() => {
+                this.recentlyCopied = false;
+            }, 1500);
+        }
+    }
+};
+
+</script>
+

--- a/website/src/components/website/dashboard/TokenModal.vue
+++ b/website/src/components/website/dashboard/TokenModal.vue
@@ -6,23 +6,20 @@
             </b-button>
         </div>
         <b-modal hide-footer ref="modal" id="token" title="SLMN.gg Token">
-            <p>
-                This token can be used for our Companion module or while using the API in another way.<br>
-            </p>
+            <p>Your <b>SLMN.GG token</b> is used to identify you and perform requests on the site.</p>
+            <p>You can use the token in our Companion module to make full use of the buttons.</p>
 
-            <p>
-                The token gives <strong>full access to SLMN.gg</strong> so you <strong>must keep it safe</strong>.
-            </p>
+            <p><b>Please note:</b> Your token gives anyone who has it <b class="text-danger">full access to your account</b> on SLMN.GG, including any permissions you have to edit matches or broadcasts.</p>
+            <p>You shouldn't share it with a third party. Only use it in programs you are running yourself.</p>
 
             <b-form-checkbox v-model="hasAccepted">
                 I will keep my token safe
             </b-form-checkbox>
 
-            <b-button v-if="token" class="mt-2" @click="copyToken" :disabled="!hasAccepted">
+            <b-button v-if="token" class="mt-3" @click="copyToken" :disabled="!hasAccepted">
                 <i :class="`fas fa-fw ${recentlyCopied ? 'fa-clipboard-check' : 'fa-copy'}`"></i> Copy token
             </b-button>
-
-            <p class="mt-2" v-else>
+            <p class="mt-3" v-else>
                 <i class="fas fa-exclamation-triangle mr-2"></i> You are not logged in.
             </p>
 

--- a/website/src/views/Dashboard.vue
+++ b/website/src/views/Dashboard.vue
@@ -47,6 +47,7 @@
             </div>
         </DashboardModule>
         <CommsControl v-if="useTeamComms" :match="liveMatch"/>
+        <TokenModal/>
     </div>
 </template>
 
@@ -68,10 +69,11 @@ import DashboardModule from "@/components/website/dashboard/DashboardModule.vue"
 import BracketImplications from "@/components/website/dashboard/BracketImplications.vue";
 import PreviewProgramDisplay from "@/components/website/dashboard/PreviewProgramDisplay.vue";
 import Bracket from "@/components/website/bracket/Bracket.vue";
+import TokenModal from "@/components/website/dashboard/TokenModal.vue";
 
 export default {
     name: "Dashboard",
-    components: { Bracket, PreviewProgramDisplay, BracketImplications, DashboardModule, DashboardClock, ScheduleEditor, BroadcastEditor, CommsControl, Commercials, Predictions, MatchEditor, MatchThumbnail, BroadcastSwitcher, BButton },
+    components: { TokenModal, Bracket, PreviewProgramDisplay, BracketImplications, DashboardModule, DashboardClock, ScheduleEditor, BroadcastEditor, CommsControl, Commercials, Predictions, MatchEditor, MatchThumbnail, BroadcastSwitcher, BButton },
     computed: {
         user() {
             if (!this.$root.auth.user?.airtableID) return {};

--- a/website/src/views/Dashboard.vue
+++ b/website/src/views/Dashboard.vue
@@ -47,7 +47,6 @@
             </div>
         </DashboardModule>
         <CommsControl v-if="useTeamComms" :match="liveMatch"/>
-        <TokenModal/>
     </div>
 </template>
 
@@ -69,11 +68,10 @@ import DashboardModule from "@/components/website/dashboard/DashboardModule.vue"
 import BracketImplications from "@/components/website/dashboard/BracketImplications.vue";
 import PreviewProgramDisplay from "@/components/website/dashboard/PreviewProgramDisplay.vue";
 import Bracket from "@/components/website/bracket/Bracket.vue";
-import TokenModal from "@/components/website/dashboard/TokenModal.vue";
 
 export default {
     name: "Dashboard",
-    components: { TokenModal, Bracket, PreviewProgramDisplay, BracketImplications, DashboardModule, DashboardClock, ScheduleEditor, BroadcastEditor, CommsControl, Commercials, Predictions, MatchEditor, MatchThumbnail, BroadcastSwitcher, BButton },
+    components: { Bracket, PreviewProgramDisplay, BracketImplications, DashboardModule, DashboardClock, ScheduleEditor, BroadcastEditor, CommsControl, Commercials, Predictions, MatchEditor, MatchThumbnail, BroadcastSwitcher, BButton },
     computed: {
         user() {
             if (!this.$root.auth.user?.airtableID) return {};


### PR DESCRIPTION
Add a way to copy the token to the dashboard following #173 
![image](https://user-images.githubusercontent.com/23165606/218252892-3f4933ab-b72b-45b2-b7be-200f87ee3ca4.png)
