### PR TITLE
Warn in local development when using non-local data server

### DIFF
--- a/website/src/components/website/WebsiteNav.vue
+++ b/website/src/components/website/WebsiteNav.vue
@@ -16,9 +16,9 @@
         <WebsiteNavBanner v-if="siteMode === 'staging'" class="bg-warning text-dark">
             <b><a href="https://github.com/slmnio/slmngg-sfc" class="text-dark">Beta development version:</a></b> things may break. Use <a href="https://slmn.gg" class="text-dark font-weight-bold">slmn.gg</a> for the latest stable update.
         </WebsiteNavBanner>
-        <WebsiteNavBanner v-if="siteMode === 'local'" :class="dataServerMode === 'local' ? 'text-light bg-primary' : 'text-dark bg-warning'">
-            <span v-if="dataServerMode === 'local'">SLMN.GG is running in local development mode.</span>
-            <span v-else><i class="fas fa-exclamation-triangle fa-fw mr-1"></i> SLMN.GG is running in local development mode <strong>but not using a local data server.</strong></span>
+        <WebsiteNavBanner v-if="siteMode === 'local'" class="text-light bg-primary">
+            <i v-if="dataServerMode !== 'local'" class="fas fa-exclamation-triangle fa-fw mr-1"></i>
+            SLMN.GG is running in local development mode<strong v-if="dataServerMode !== 'local'"> but not using a local data server</strong>.
         </WebsiteNavBanner>
 <!--       example: <WebsiteNavBanner class="bg-success" v-if="$socket.connected">Connected to the data server for live data updates!</WebsiteNavBanner>-->
 

--- a/website/src/components/website/WebsiteNav.vue
+++ b/website/src/components/website/WebsiteNav.vue
@@ -16,8 +16,9 @@
         <WebsiteNavBanner v-if="siteMode === 'staging'" class="bg-warning text-dark">
             <b><a href="https://github.com/slmnio/slmngg-sfc" class="text-dark">Beta development version:</a></b> things may break. Use <a href="https://slmn.gg" class="text-dark font-weight-bold">slmn.gg</a> for the latest stable update.
         </WebsiteNavBanner>
-        <WebsiteNavBanner v-if="siteMode === 'local'" class="bg-primary text-light">
-            SLMN.GG is running in local development mode.
+        <WebsiteNavBanner v-if="siteMode === 'local'" :class="dataServerMode === 'local' ? 'text-light bg-primary' : 'text-dark bg-warning'">
+            <span v-if="dataServerMode === 'local'">SLMN.GG is running in local development mode.</span>
+            <span v-else><i class="fas fa-exclamation-triangle fa-fw mr-1"></i> SLMN.GG is running in local development mode <strong>but not using a local data server.</strong></span>
         </WebsiteNavBanner>
 <!--       example: <WebsiteNavBanner class="bg-success" v-if="$socket.connected">Connected to the data server for live data updates!</WebsiteNavBanner>-->
 
@@ -147,6 +148,10 @@ export default {
         },
         siteMode() {
             return import.meta.env.VITE_DEPLOY_MODE || import.meta.env.NODE_ENV;
+        },
+        dataServerMode() {
+            const dataServerURL = new URL(import.meta.env.VITE_DATA_SERVER);
+            return ["localhost", "127.0.0.1"].includes(dataServerURL.hostname) ? "local" : "remote";
         },
         navbarEvents() {
             if (!this.minisite?.id) return [];


### PR DESCRIPTION
Sometimes it's useful to run the SLMN.gg frontend with the production data server instead of spinning up a local one.  
However, this can lead to a lot of confusion when you don't notice you're on the wrong data server and your changes aren't showing up. 
This PR adds a banner during local development when the data server is not running on `localhost`/`127.0.0.1`.
![image](https://github.com/slmnio/slmngg-sfc/assets/23165606/081d7025-2e4f-44f2-860c-e250d6b4aa1a)
