### PR TITLE
feat: When no bracket key or bracket key 'match' take match bracket

### DIFF
--- a/website/src/components/broadcast/roots/BracketOverlay.vue
+++ b/website/src/components/broadcast/roots/BracketOverlay.vue
@@ -42,7 +42,7 @@ export default {
             if (this.bracketKey) key = this.bracketKey;
 
             if ((!key || key === "match") && this.liveMatch) {
-                key = this.liveMatch.brackets[0].key;
+                key = this.liveMatch.brackets?.[0]?.key || key;
             }
 
             if (!key) return this.event.brackets[0];

--- a/website/src/components/broadcast/roots/BracketOverlay.vue
+++ b/website/src/components/broadcast/roots/BracketOverlay.vue
@@ -41,8 +41,8 @@ export default {
             if (this.broadcast?.bracket_key) key = this.broadcast.bracket_key;
             if (this.bracketKey) key = this.bracketKey;
 
-            if ((!key || key === "match") && this.liveMatch) {
-                key = this.liveMatch.brackets?.[0]?.key || key;
+            if (this.liveMatch && (!key || key === "match")) {
+                key = this.liveMatch.brackets?.[0]?.key;
             }
 
             if (!key) return this.event.brackets[0];

--- a/website/src/components/broadcast/roots/BracketOverlay.vue
+++ b/website/src/components/broadcast/roots/BracketOverlay.vue
@@ -41,6 +41,10 @@ export default {
             if (this.broadcast?.bracket_key) key = this.broadcast.bracket_key;
             if (this.bracketKey) key = this.bracketKey;
 
+            if ((!key || key === "match") && this.liveMatch) {
+                key = this.liveMatch.brackets[0].key;
+            }
+
             if (!key) return this.event.brackets[0];
             const bracket = this.event.brackets.find(b => b && b.key === key);
             return bracket || this.event.brackets[0];
@@ -52,7 +56,8 @@ export default {
         liveMatch() {
             if (!this.broadcast?.live_match) return null;
             return ReactiveRoot(this.broadcast.live_match[0], {
-                teams: ReactiveArray("teams")
+                teams: ReactiveArray("teams"),
+                brackets: ReactiveArray("brackets")
             });
         },
         highlightMatch() {


### PR DESCRIPTION
When a broadcast's bracket key is empty or set to `match` it will resolve bracket based on `liveMatch`. Setting to a specific bracket key will still work as before.