### PR TITLE
Turn the credits copy button on the match details page into a modal with multiple formats

### DIFF
--- a/website/src/components/website/CreditCreator.vue
+++ b/website/src/components/website/CreditCreator.vue
@@ -12,7 +12,6 @@
 </template>
 <script>
 import { ReactiveArray, ReactiveRoot, ReactiveThing } from "@/utils/reactive";
-import CopyTextButton from "@/components/website/CopyTextButton.vue";
 
 // theoretically we could move this into airtable instead
 const roleMap = {
@@ -28,10 +27,10 @@ const roleMap = {
 
 export default {
     name: "CreditCreator",
-    components: { CopyTextButton },
     props: ["id"],
     data: () => ({
         lastCopied: "",
+        copyTimeout: null,
         templates: [
             {
                 name: "Twitter",
@@ -109,8 +108,10 @@ export default {
         async copy(text, name) {
             await navigator.clipboard.writeText(text);
             this.lastCopied = name;
-            await new Promise(resolve => setTimeout(resolve, 1000));
-            this.lastCopied = "";
+            if (this.copyTimeout) clearTimeout(this.copyTimeout);
+            this.copyTimeout = setTimeout(() => {
+                this.lastCopied = "";
+            }, 1000);
         }
     }
 };

--- a/website/src/components/website/CreditCreator.vue
+++ b/website/src/components/website/CreditCreator.vue
@@ -2,8 +2,9 @@
     <b-button v-b-modal.socials-modal>Credits</b-button>
     <b-modal id="socials-modal" title="Credits" hide-footer>
         <div v-for="template in templates" :key="template.name">
-            <h2>
-                <CopyTextButton :content="template.template(groups)">{{ template.name }}</CopyTextButton>
+            <h2 class="d-flex align-items-center gap-2">
+                {{ template.name }}
+                <b-button size="sm" @click="copy(template.template(groups), template.name)">{{ lastCopied === template.name ? 'Copied' : 'Copy' }}</b-button>
             </h2>
             <pre>{{ template.template(groups) }}</pre>
         </div>
@@ -30,21 +31,19 @@ export default {
     components: { CopyTextButton },
     props: ["id"],
     data: () => ({
-        roleMode: "emoji",
-        linkMode: "mention",
-        displayMode: "block",
+        lastCopied: "",
         templates: [
             {
                 name: "Twitter",
                 template: (groups) => {
                     return groups?.flatMap(g => g?.items?.map(p => `${g.meta.emoji} ${p?.twitter_link?.length ? p.twitter_link[0].replace("https://twitter.com/", "@") : p.name}`)).join("\n");
-                }
+                },
             },
             {
                 name: "Twitter Inline",
                 template: (groups) => {
                     return groups?.map(g => `${g.meta.emoji} ${g?.items?.map(p => `${p?.twitter_link?.length ? p.twitter_link[0].replace("https://twitter.com/", "@") : p.name}`).join(" ")}`).join("\n");
-                }
+                },
             },
             {
                 name: "YouTube",
@@ -52,7 +51,7 @@ export default {
                     return groups?.map(g => {
                         return `${g.meta.name}\n${g?.items?.map(p => `${p.name} ${p?.twitter_link?.length ? p.twitter_link[0] : ""}`).join("\n")}`;
                     }).join("\n\n");
-                }
+                },
             }
         ]
     }),
@@ -104,6 +103,14 @@ export default {
                 group.meta.emoji = roleMap[group.meta.singular_name] || "";
                 return group;
             });
+        }
+    },
+    methods: {
+        async copy(text, name) {
+            await navigator.clipboard.writeText(text);
+            this.lastCopied = name;
+            await new Promise(resolve => setTimeout(resolve, 1000));
+            this.lastCopied = "";
         }
     }
 };

--- a/website/src/components/website/CreditCreator.vue
+++ b/website/src/components/website/CreditCreator.vue
@@ -1,0 +1,116 @@
+<template>
+    <b-button v-b-modal.socials-modal>Credits</b-button>
+    <b-modal id="socials-modal" title="Credits" hide-footer>
+        <div v-for="template in templates" :key="template.name">
+            <h2>
+                <CopyTextButton :content="template.template(groups)">{{ template.name }}</CopyTextButton>
+            </h2>
+            <pre>{{ template.template(groups) }}</pre>
+        </div>
+    </b-modal>
+</template>
+<script>
+import { ReactiveArray, ReactiveRoot, ReactiveThing } from "@/utils/reactive";
+import CopyTextButton from "@/components/website/CopyTextButton.vue";
+
+// theoretically we could move this into airtable instead
+const roleMap = {
+    "Caster": "🎙️",
+    "Producer": "🎬",
+    "Observer": "📹",
+    "Observer Director": "🎞️",
+    "Desk Host": "🎤",
+    "Replay Producer": "🔁",
+    "Lobby Admin": "🎟️",
+};
+
+
+export default {
+    name: "CreditCreator",
+    components: { CopyTextButton },
+    props: ["id"],
+    data: () => ({
+        roleMode: "emoji",
+        linkMode: "mention",
+        displayMode: "block",
+        templates: [
+            {
+                name: "Twitter",
+                template: (groups) => {
+                    return groups?.flatMap(g => g?.items?.map(p => `${g.meta.emoji} ${p?.twitter_link?.length ? p.twitter_link[0].replace("https://twitter.com/", "@") : p.name}`)).join("\n");
+                }
+            },
+            {
+                name: "Twitter Inline",
+                template: (groups) => {
+                    return groups?.map(g => `${g.meta.emoji} ${g?.items?.map(p => `${p?.twitter_link?.length ? p.twitter_link[0].replace("https://twitter.com/", "@") : p.name}`).join(" ")}`).join("\n");
+                }
+            },
+            {
+                name: "YouTube",
+                template: (groups) => {
+                    return groups?.map(g => {
+                        return `${g.meta.name}\n${g?.items?.map(p => `${p.name} ${p?.twitter_link?.length ? p.twitter_link[0] : ""}`).join("\n")}`;
+                    }).join("\n\n");
+                }
+            }
+        ]
+    }),
+    computed: {
+        match() {
+            return ReactiveRoot(this.id, {
+                casters: ReactiveArray("casters"),
+                player_relationships: ReactiveArray("player_relationships", {
+                    player: ReactiveThing("player", {
+                        clients: ReactiveArray("clients")
+                    })
+                })
+            });
+        },
+        playerRelationshipGroups() {
+            if (!this.match?.player_relationships) return [];
+            const groups = {};
+
+            this.match?.player_relationships.forEach(rel => {
+                if (!groups[rel.singular_name]) {
+                    groups[rel.singular_name] = {
+                        meta: {
+                            player_text: rel.player_text,
+                            plural_name: rel.plural_name,
+                            singular_name: rel.singular_name
+                        },
+                        items: []
+                    };
+                }
+                groups[rel.singular_name].items = groups[rel.singular_name].items.concat(rel.player);
+            });
+
+            if (groups[undefined]) return [];
+
+            return Object.values(groups);
+        },
+        groups() {
+            return [
+                {
+                    meta: {
+                        singular_name: "Caster",
+                        plural_name: "Casters"
+                    },
+                    items: this.match?.casters
+                },
+                ...this.playerRelationshipGroups
+            ].map(group => {
+                group.meta.name = group.items?.length === 1 ? group.meta.singular_name : group.meta.plural_name;
+                group.meta.emoji = roleMap[group.meta.singular_name] || "";
+                return group;
+            });
+        }
+    }
+};
+</script>
+
+<style scoped>
+h2 {
+    font-size: 1.5em;
+}
+</style>

--- a/website/src/views/DetailedMatch.vue
+++ b/website/src/views/DetailedMatch.vue
@@ -218,12 +218,7 @@
                             <a class="ct-active" :href="matchThumbnailURL(match, 1080)" rel="nofollow" target="_blank">1080p</a>
                         </template>
                     </stat>
-                    <stat v-if="credits">
-                        Credits
-                        <template #content>
-                            <CopyTextButton style="white-space: pre" :content="credits">Copy credits</CopyTextButton>
-                        </template>
-                    </stat>
+                    <CreditCreator :id="id" />
                 </div>
             </div>
         </div>
@@ -246,10 +241,11 @@ import { getDataServerAddress } from "@/utils/fetch";
 import { canEditMatch } from "@/utils/client-action-permissions";
 import MatchHistory from "@/views/sub-views/MatchHistory.vue";
 import { useAuthStore } from "@/stores/authStore";
+import CreditCreator from "@/components/website/CreditCreator.vue";
 
 export default {
     name: "DetailedMatch",
-    components: { MatchHistory, BracketImplications, CopyTextButton, Markdown, PreviousMatch, ThemeLogo, MapDisplay, stat: DetailedMatchStat },
+    components: { CreditCreator, MatchHistory, BracketImplications, CopyTextButton, Markdown, PreviousMatch, ThemeLogo, MapDisplay, stat: DetailedMatchStat },
     props: ["id"],
     data: () => ({
         showPlayerInfo: false,
@@ -345,25 +341,6 @@ export default {
             return Object.entries(groups).sort(([aSubEvent, aData], [bSubEvent, bData]) => {
                 return bData.earliest - aData.earliest;
             });
-        },
-        credits() {
-            const groups = [
-                {
-                    meta: {
-                        singular_name: "Caster",
-                        plural_name: "Casters"
-                    },
-                    items: this.match?.casters
-                },
-                ...this.playerRelationshipGroups
-            ];
-
-            console.log("credits groups", groups);
-
-            return groups.filter(g => g.items?.length).map(group => [
-                (group.items?.length === 1 ? group.meta.singular_name + ": " : group.meta.plural_name + ":"),
-                group.items?.map(p => p.name + (p.twitter_link ? " " + p.twitter_link : "")).join("\n")
-            ].join("\n")).join("\n\n");
         },
         _theme() {
             return this.match?.event?.theme;


### PR DESCRIPTION
Until now there was only a format for YouTube descriptions, I've added new ones for twitter with both a large and inline variant.
This could be expanded with additional formats in the future. I've also hardcoded the emoji for prod roles here, theoretically this could be moved into airtable but idk if it's worth the effort.

![image](https://github.com/slmnio/slmngg-sfc/assets/23165606/815a828f-e8d5-4986-b6c3-43493d8ca8c2)
