### PR TITLE
Create producing guide

### DIFF
--- a/website/src/router/default.js
+++ b/website/src/router/default.js
@@ -119,6 +119,13 @@ export default [
                             { path: "", component: () => import("@/views/sub-views/guide/companion-module/CompanionModuleGuideIntro.vue"), name: "companion-module" }
                         ]
                     },
+                    {
+                        path: "producing",
+                        component: () => import("@/views/sub-views/guide/producing/ProducingGuideContainer.vue"),
+                        children: [
+                            { path: "", component: () => import("@/views/sub-views/guide/producing/ProducingGuideIntro.vue"), name: "producing-guide" }
+                        ]
+                    },
                 ],
             },
             {

--- a/website/src/views/Learn.vue
+++ b/website/src/views/Learn.vue
@@ -13,6 +13,9 @@
                 <router-link :to="{ name: 'observing-tech-guide' }">Observer Tech Guide</router-link>
             </li>
             <li>
+                <router-link :to="{ name: 'producing-guide' }">Producing Guide</router-link>
+            </li>
+            <li>
                 <router-link :to="{ name: 'overwatch-settings' }">Overwatch Settings Guide</router-link>
             </li>
             <li style="opacity: 0.8">

--- a/website/src/views/sub-views/guide/producing/ProducingGuideContainer.vue
+++ b/website/src/views/sub-views/guide/producing/ProducingGuideContainer.vue
@@ -1,0 +1,25 @@
+<template>
+    <div class="container">
+        <LearnTitleChip subtitle="Producing Guide" />
+
+        <SubPageNav class="my-2">
+            <li class="nav-item ct-passive">
+                <router-link class="nav-link" :to="{ name: 'producing-guide'}">Intro</router-link>
+            </li>
+        </SubPageNav>
+        <router-view />
+    </div>
+</template>
+
+<script>
+import LearnTitleChip from "@/components/website/guide/LearnTitleChip.vue";
+import SubPageNav from "@/components/website/SubPageNav.vue";
+
+export default {
+    name: "ProducingGuideContainer",
+    components: {
+        SubPageNav,
+        LearnTitleChip
+    }
+};
+</script>

--- a/website/src/views/sub-views/guide/producing/ProducingGuideIntro.vue
+++ b/website/src/views/sub-views/guide/producing/ProducingGuideIntro.vue
@@ -1,0 +1,35 @@
+<template>
+    <div class="container">
+        <section>
+            <h2>Intro to SLMN.GG Productions</h2>
+            <p>Hundreds of hours of development time and <a href="https://github.com/slmnio/slmngg-sfc" target="_blank">thousands of commits</a> have built up the SLMN.GG platform. It functions as a public facing website, and a system of graphics for productions.</p>
+            <h3>Why SLMN.GG?</h3>
+            <p>The goals driving SLMN.GG are <b>consistency</b> and <b>automation</b>. All broadcasts in the same event look identical, running at the same time across multiple production teams. Every match has the same level of polish as the last. Team designs are consistent across the broadcast, and styling affects each component for a fully unique themed experience.</p>
+            <p>There is always the data you need to tell the story you need to tell. Rosters are always there, ready for display, and with full details for casters so they can be accurate. Schedules, standings and brackets are updated live across every component. You won't need to run with outdated data or depend on an external bracket or provider.</p>
+            <p>The more we design, the more becomes available for subsequent broadcasts. New components are built broadcast-agnostic to keep pushing the broadcast quality higher.</p>
+            <p>We have scene collection generators and automatic broadcast changing so our producers can work on the most important parts of the broadcast, not fiddling with scene collections every time they start something new.</p>
+            <h3>What works best?</h3>
+            <p>SLMN.GG works best when you use it multiple times. Long tournaments like leagues are ideal for our comparison graphics. Groups stages can be effortlessly calculated with our built-in automatic scenarios generator. Follow teams throughout a tournament and tell their story.</p>
+            <p>SLMN.GG is not ideal for one-off streams. There is some effort required to set up a broadcast with its theming and customisation, and you lose out on some of the benefits of pre-set data and comparisons. It is not really built as a generic broadcasting tool for individual games.</p>
+            <p>However, SLMN.GG is <a href="https://github.com/slmnio/slmngg-sfc/graphs/commit-activity" target="_blank">always evolving</a>, more features are being added, and more control delegated to event staff and producers.</p>
+        </section>
+        <section>
+            <h2>Setting Up</h2>
+            <ul>
+                <li>SLMN.GG is designed to work in <a href="https://obsproject.com/download" target="_blank">OBS Studio</a>. Download the latest version for the best results.</li>
+                <li>Our <router-link :to="{'name': 'companion-module'}">Companion module</router-link> works directly with our servers to give you ultimate control of your broadcast.</li>
+                <li>Download the latest <router-link :to="{'name':'obs-scene-collections'}">SLMN.GG OBS Scene Collection</router-link> for our newest broadcast package changes.</li>
+            </ul>
+        </section>
+    </div>
+</template>
+
+<script>
+export default {
+    name: "ProducingGuideIntro",
+};
+</script>
+
+<style scoped>
+
+</style>


### PR DESCRIPTION
Another guide that we should have started work on a long time ago. 

To add:

- [ ] Downloading, explaining and importing the scene collection
- [ ] Setting up a secondary Discord client (through Canary or PTB), how to screenshare, dealing with issues (i.e. disabling preview/studio mode/multiview if it breaks)
- [ ] Setting up caster audio (either embedded Discord, but probably deprecating that and moving to application audio capture or virtual cables from the secondary client)
- [ ] Installing plugins: transition table, anything else?
- [ ] Setting up the websocket transmitter
- [ ] Links to the companion module for stream decks
- [ ] Dashboard overview

Worth getting feedback from new and experienced producers for their best advice.