### PR TITLE
Rescheduling system

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "globals": "^15.1.0",
     "postcss-html": "^1.6.0",
     "typescript": "^5.4.5",
-    "typescript-eslint": "^7.8.0"
+    "typescript-eslint": "^7.8.0",
+    "@vue/language-server": "^2.1.10"
   },
   "packageManager": "pnpm@9.1.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@eslint/js':
         specifier: ^9.2.0
         version: 9.2.0
+      '@vue/language-server':
+        specifier: ^2.1.10
+        version: 2.1.10(typescript@5.4.5)
       eslint:
         specifier: ^8.57.0
         version: 8.57.0
@@ -207,7 +210,7 @@ importers:
         version: 9.25.0(eslint@8.57.0)
       unplugin-vue-components:
         specifier: ^0.26.0
-        version: 0.26.0(@babel/parser@7.24.5)(rollup@4.17.2)(vue@3.4.27(typescript@5.4.5))
+        version: 0.26.0(@babel/parser@7.26.3)(rollup@4.17.2)(vue@3.4.27(typescript@5.4.5))
       vite:
         specifier: ^5.2.11
         version: 5.2.11(@types/node@22.5.5)
@@ -228,8 +231,16 @@ packages:
     resolution: {integrity: sha512-2ofRCjnnA9y+wk8b9IAREroeUP02KHp431N2mhKniy2yKIDKpbrHv9eXwm8cBeWQYcJmzv5qKCu65P47eCF7CQ==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.25.9':
+    resolution: {integrity: sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.24.5':
     resolution: {integrity: sha512-3q93SSKX2TWCG30M2G2kwaKeTYgEUp5Snjuj8qm729SObL6nbtUldAi37qbxkD5gg3xnBio+f9nqpSepGZMvxA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.25.9':
+    resolution: {integrity: sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/highlight@7.24.5':
@@ -241,12 +252,21 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/parser@7.26.3':
+    resolution: {integrity: sha512-WJ/CvmY8Mea8iDXo6a7RK2wbmJITT5fN3BEkRuFlxVyNx8jOKIIhmC4fSkTcPcf8JyavbBwIe6OpiCOBXt/IcA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/runtime@7.24.5':
     resolution: {integrity: sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.24.5':
     resolution: {integrity: sha512-6mQNsaLeXTw0nxYUYu+NSa4Hx4BlF1x1x8/PMFbiR+GBSr+2DkECc69b8hgy2frEodNcvPffeH8YfWd3LI6jhQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.26.3':
+    resolution: {integrity: sha512-vN5p+1kl59GVKMvTHt55NzzmYVxprfJD+ql7U9NFIfKCBkYE55LYtS+WtPlaYOyzydrKI8Nezd+aZextrd+FMA==}
     engines: {node: '>=6.9.0'}
 
   '@d-fischer/cache-decorators@4.0.1':
@@ -313,6 +333,27 @@ packages:
   '@discordjs/ws@1.1.0':
     resolution: {integrity: sha512-O97DIeSvfNTn5wz5vaER6ciyUsr7nOqSEtsLoMhhIgeFkhnxLRqSr00/Fpq2/ppLgjDGLbQCDzIK7ilGoB/M7A==}
     engines: {node: '>=16.11.0'}
+
+  '@emmetio/abbreviation@2.3.3':
+    resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
+
+  '@emmetio/css-abbreviation@2.1.8':
+    resolution: {integrity: sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==}
+
+  '@emmetio/css-parser@0.4.0':
+    resolution: {integrity: sha512-z7wkxRSZgrQHXVzObGkXG+Vmj3uRlpM11oCZ9pbaz0nFejvCDmAiNDpY75+wgXOcffKpj4rzGtwGaZxfJKsJxw==}
+
+  '@emmetio/html-matcher@1.3.0':
+    resolution: {integrity: sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==}
+
+  '@emmetio/scanner@1.0.4':
+    resolution: {integrity: sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==}
+
+  '@emmetio/stream-reader-utils@0.1.0':
+    resolution: {integrity: sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==}
+
+  '@emmetio/stream-reader@2.2.0':
+    resolution: {integrity: sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==}
 
   '@emnapi/runtime@1.2.0':
     resolution: {integrity: sha512-bV21/9LQmcQeCPEg3BDFtvwL6cwiTMksYNWQQ4KOxCZikEGalWtenoZ0wCiukJINlGCIi2KXx01g4FoH/LxpzQ==}
@@ -769,6 +810,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@johnsoncodehk/pug-beautify@0.2.2':
+    resolution: {integrity: sha512-qqNS/YD0Nck5wtQLCPHAfGVgWbbGafxSPjNh0ekYPFSNNqnDH2kamnduzYly8IiADmeVx/MfAE1njMEjVeHTMA==}
+
   '@jridgewell/sourcemap-codec@1.4.15':
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
 
@@ -1049,23 +1093,56 @@ packages:
   '@volar/language-core@2.2.1':
     resolution: {integrity: sha512-iHJAZKcYldZgyS8gx6DfIZApViVBeqbf6iPhqoZpG5A6F4zsZiFldKfwaKaBA3/wnOTWE2i8VUbXywI1WywCPg==}
 
+  '@volar/language-core@2.4.11':
+    resolution: {integrity: sha512-lN2C1+ByfW9/JRPpqScuZt/4OrUUse57GLI6TbLgTIqBVemdl1wNcZ1qYGEo2+Gw8coYLgCy7SuKqn6IrQcQgg==}
+
+  '@volar/language-server@2.4.11':
+    resolution: {integrity: sha512-W9P8glH1M8LGREJ7yHRCANI5vOvTrRO15EMLdmh5WNF9sZYSEbQxiHKckZhvGIkbeR1WAlTl3ORTrJXUghjk7g==}
+
+  '@volar/language-service@2.4.11':
+    resolution: {integrity: sha512-KIb6g8gjUkS2LzAJ9bJCLIjfsJjeRtmXlu7b2pDFGD3fNqdbC53cCAKzgWDs64xtQVKYBU13DLWbtSNFtGuMLQ==}
+
   '@volar/source-map@2.2.1':
     resolution: {integrity: sha512-w1Bgpguhbp7YTr7VUFu6gb4iAZjeEPsOX4zpgiuvlldbzvIWDWy4t0jVifsIsxZ99HAu+c3swiME7wt+GeNqhA==}
+
+  '@volar/source-map@2.4.11':
+    resolution: {integrity: sha512-ZQpmafIGvaZMn/8iuvCFGrW3smeqkq/IIh9F1SdSx9aUl0J4Iurzd6/FhmjNO5g2ejF3rT45dKskgXWiofqlZQ==}
+
+  '@volar/test-utils@2.4.11':
+    resolution: {integrity: sha512-ogkLldPqFa/j9302Ns+nWeyTCQv8d4c7iN4t8ziq7j0XeMKWYsTAjLsx/9z0MTNrecBAcocgzEvCricASSq+Hw==}
 
   '@volar/typescript@2.2.1':
     resolution: {integrity: sha512-Z/tqluR7Hz5/5dCqQp7wo9C/6tSv/IYl+tTzgzUt2NjTq95bKSsuO4E+V06D0c+3aP9x5S9jggLqw451hpnc6Q==}
 
+  '@volar/typescript@2.4.11':
+    resolution: {integrity: sha512-2DT+Tdh88Spp5PyPbqhyoYavYCPDsqbHLFwcUI9K1NlY1YgUJvujGdrqUp0zWxnW7KWNTr3xSpMuv2WnaTKDAw==}
+
+  '@vscode/emmet-helper@2.11.0':
+    resolution: {integrity: sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==}
+
+  '@vscode/l10n@0.0.18':
+    resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
+
   '@vue/compiler-core@3.4.27':
     resolution: {integrity: sha512-E+RyqY24KnyDXsCuQrI+mlcdW3ALND6U7Gqa/+bVwbcpcR3BRRIckFoz7Qyd4TTlnugtwuI7YgjbvsLmxb+yvg==}
 
+  '@vue/compiler-core@3.5.13':
+    resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
+
   '@vue/compiler-dom@3.4.27':
     resolution: {integrity: sha512-kUTvochG/oVgE1w5ViSr3KUBh9X7CWirebA3bezTbB5ZKBQZwR2Mwj9uoSKRMFcz4gSMzzLXBPD6KpCLb9nvWw==}
+
+  '@vue/compiler-dom@3.5.13':
+    resolution: {integrity: sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==}
 
   '@vue/compiler-sfc@3.4.27':
     resolution: {integrity: sha512-nDwntUEADssW8e0rrmE0+OrONwmRlegDA1pD6QhVeXxjIytV03yDqTey9SBDiALsvAd5U4ZrEKbMyVXhX6mCGA==}
 
   '@vue/compiler-ssr@3.4.27':
     resolution: {integrity: sha512-CVRzSJIltzMG5FcidsW0jKNQnNRYC8bT21VegyMMtHmhW3UOI7knmUehzswXLrExDLE6lQCZdrhD4ogI7c+vuw==}
+
+  '@vue/compiler-vue2@2.7.16':
+    resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
 
   '@vue/devtools-api@6.6.1':
     resolution: {integrity: sha512-LgPscpE3Vs0x96PzSSB4IGVSZXZBZHpfxs+ZA1d+VEPwHdOXowy/Y2CsvCAIFrf+ssVU1pD1jidj505EpUnfbA==}
@@ -1077,6 +1154,21 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  '@vue/language-core@2.1.10':
+    resolution: {integrity: sha512-DAI289d0K3AB5TUG3xDp9OuQ71CnrujQwJrQnfuZDwo6eGNf0UoRlPuaVNO+Zrn65PC3j0oB2i7mNmVPggeGeQ==}
+    peerDependencies:
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@vue/language-server@2.1.10':
+    resolution: {integrity: sha512-Cjxi6nmMVDxOpWWfq1jCe9UqHg/WrTxwZGAXtYXByOhueiRi1kOlHR77vkRQRi40jpZIPWEnjgD/jMMhfLe0ag==}
+    hasBin: true
+
+  '@vue/language-service@2.1.10':
+    resolution: {integrity: sha512-voNteQNU+mHUmyUEdHUpWZW5/kfLQxh1zHs98c5hw6XK6pNxJTghG/k4maka6y5WmfmMCKAsddBpD9kZ7lyAlg==}
 
   '@vue/reactivity@3.4.27':
     resolution: {integrity: sha512-kK0g4NknW6JX2yySLpsm2jlunZJl2/RJGZ0H9ddHdfBVHcNzxmQ0sS0b09ipmBoQpY8JM2KmUw+a6sO8Zo+zIA==}
@@ -1095,8 +1187,14 @@ packages:
   '@vue/shared@3.4.27':
     resolution: {integrity: sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA==}
 
+  '@vue/shared@3.5.13':
+    resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
+
   '@vue/tsconfig@0.5.1':
     resolution: {integrity: sha512-VcZK7MvpjuTPx2w6blwnwZAu5/LgBUtejFOi3pPGQFXQN5Ela03FUtd2Qtg4yWGGissVL0dr6Ro1LfOFh+PCuQ==}
+
+  '@vue/typescript-plugin@2.1.10':
+    resolution: {integrity: sha512-NrS3BB3l5vuZHU4Vp8l9TbT5pC7VjBfwZKqc24dAXF3Z+dJyGs4mcC3zo59gUggLMQSah8mdXj8xqEfMkrps8w==}
 
   '@vueuse/core@10.9.0':
     resolution: {integrity: sha512-/1vjTol8SXnx6xewDEKfS0Ra//ncg4Hb0DaZiwKf7drgfMsKFExQ+FnnENcN6efPen+1kIzhLQoGSy0eDUVOMg==}
@@ -1134,6 +1232,11 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
+  acorn@7.4.1:
+    resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   acorn@8.11.3:
     resolution: {integrity: sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==}
     engines: {node: '>=0.4.0'}
@@ -1153,6 +1256,9 @@ packages:
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  alien-signals@0.2.2:
+    resolution: {integrity: sha512-cZIRkbERILsBOXTQmMrxc9hgpxglstn69zm+F1ARf4aPAzdAFYd6sBq87ErO0Fj3DV94tglcyHG5kQz9nDC/8A==}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1252,8 +1358,16 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  call-bind-apply-helpers@1.0.1:
+    resolution: {integrity: sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==}
+    engines: {node: '>= 0.4'}
+
   call-bind@1.0.7:
     resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.3:
+    resolution: {integrity: sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==}
     engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
@@ -1282,6 +1396,9 @@ packages:
   chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  character-parser@2.2.0:
+    resolution: {integrity: sha512-+UqJQjFEFaTAs3bNsF2j2kEN1baG/zghZbdqoYEDxGZtJo9LBzl1A+m0D4n3qKx8N2FNv8/Xp6yV9mQmBuptaw==}
 
   cheminfo-types@1.7.3:
     resolution: {integrity: sha512-KIKBULfo+XwkSBwMfwjBmZCmY+RXisN2kRc33WikuWBsCQQy5alHWYVrMCO8//lDvy9h1giOzwsC9kgq0OahUw==}
@@ -1495,11 +1612,18 @@ packages:
     resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
     engines: {node: '>=12'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   ee-first@1.1.1:
     resolution: {integrity: sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=}
 
   efrt-unpack@2.2.0:
     resolution: {integrity: sha512-9xUSSj7qcUxz+0r4X3+bwUNttEfGfK5AH+LVa1aTpqdAfrN5VhROYCfcF+up4hp5OL7IUKcZJJrzAGipQRDoiQ==}
+
+  emmet@2.4.11:
+    resolution: {integrity: sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1530,8 +1654,16 @@ packages:
     resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
     engines: {node: '>= 0.4'}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.0.0:
+    resolution: {integrity: sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==}
     engines: {node: '>= 0.4'}
 
   esbuild@0.20.2:
@@ -1705,6 +1837,10 @@ packages:
     resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
     engines: {node: '>= 0.4'}
 
+  get-intrinsic@1.2.6:
+    resolution: {integrity: sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==}
+    engines: {node: '>= 0.4'}
+
   get-tsconfig@4.8.1:
     resolution: {integrity: sha512-k9PN+cFBmaLWtVz29SkUoqU5O0slLuHJXt/2P+tMVFT+phsSGXGkp9t3rQIqdz0e+06EHNGs3oM6ZX1s2zHxRg==}
 
@@ -1737,6 +1873,10 @@ packages:
 
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1771,6 +1911,14 @@ packages:
 
   has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
   has-unicode@2.0.1:
@@ -1881,6 +2029,9 @@ packages:
   is-core-module@2.13.1:
     resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
 
+  is-expression@4.0.0:
+    resolution: {integrity: sha512-zMIXX63sxzG3XrkHkrAPvm/OVZVSCPNkwMHU8oTX7/U3AL78I0QXCEICXUM13BIa8TYGZ68PiTKfQz3yaTNr4A==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1915,6 +2066,10 @@ packages:
   is-plain-obj@1.1.0:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
 
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
@@ -1958,6 +2113,12 @@ packages:
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  jsonc-parser@2.3.1:
+    resolution: {integrity: sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
   junk@4.0.1:
     resolution: {integrity: sha512-Qush0uP+G8ZScpGMZvHUiRfI0YBWuB3gVBYlI0v0vvOJt5FLicco+IkP0a50LqTTQhmts/m6tP5SWE+USyIvcQ==}
@@ -2037,6 +2198,10 @@ packages:
     resolution: {integrity: sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==}
     engines: {node: '>= 18'}
     hasBin: true
+
+  math-intrinsics@1.0.0:
+    resolution: {integrity: sha512-4MqMiKP90ybymYvsut0CH2g4XWbfLtmlCkXmtmdcDCxNB+mQcu1w/1+L/VD7vi/PSv7X2JYV7SCcR+jiPXnQtA==}
+    engines: {node: '>= 0.4'}
 
   media-typer@0.3.0:
     resolution: {integrity: sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=}
@@ -2453,6 +2618,15 @@ packages:
   pstree.remy@1.1.8:
     resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
 
+  pug-error@2.1.0:
+    resolution: {integrity: sha512-lv7sU9e5Jk8IeUheHata6/UThZ7RK2jnaaNztxfPYUY+VxZyk/ePVaNZ/vwmH8WqGvDz3LrNYt/+gA55NDg6Pg==}
+
+  pug-lexer@5.0.1:
+    resolution: {integrity: sha512-0I6C62+keXlZPZkOJeVam9aBLVP2EnbeDw3An+k0/QlqdwH6rv8284nko14Na7c0TtqtogfWXcRoFE4O4Ff20w==}
+
+  pug-parser@6.0.0:
+    resolution: {integrity: sha512-ukiYM/9cH6Cml+AOl5kETtM9NR3WulyVP2y4HOU45DyMim1IeP/OOiyEWRr6qk5I5klpsBnbuHpwKmTx6WURnw==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -2501,6 +2675,9 @@ packages:
 
   regexp-to-ast@0.4.0:
     resolution: {integrity: sha512-4qf/7IsIKfSNHQXSwial1IFmfM1Cc/whNBQqRwe0V2stPe7KmN1U0tWQiIx6JiirgSrisjE0eECdNf7Tav1Ntw==}
+
+  request-light@0.7.0:
+    resolution: {integrity: sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2564,6 +2741,11 @@ packages:
 
   semver@7.6.1:
     resolution: {integrity: sha512-f/vbBsu+fOiYt+lmwZV0rVwJScl46HppnOA1ZvIuBWKOTlllpyJ3bfVax76/OrhCH38dyxoDIA8K7uB963IYgA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.6.3:
+    resolution: {integrity: sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2732,6 +2914,9 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  token-stream@1.0.0:
+    resolution: {integrity: sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==}
+
   touch@3.1.0:
     resolution: {integrity: sha512-WBx8Uy5TLtOSRtIq+M03/sKDrXCLHxwDcquSP2c43Le03/9serjQBIztjRz6FkJez9D/hleyAXTBGLwwZUw9lA==}
     hasBin: true
@@ -2785,6 +2970,9 @@ packages:
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
+
+  typescript-auto-import-cache@0.3.5:
+    resolution: {integrity: sha512-fAIveQKsoYj55CozUiBoj4b/7WpN0i4o74wiGY5JVUEoD0XiqDk1tJqTEjgzL2/AizKQrXxyRosSebyDzBZKjw==}
 
   typescript-eslint@7.8.0:
     resolution: {integrity: sha512-sheFG+/D8N/L7gC3WT0Q8sB97Nm573Yfr+vZFzl/4nBdYcmviBPtwGSX9TJ7wpVg28ocerKVOt+k2eGmHzcgVA==}
@@ -2882,6 +3070,97 @@ packages:
         optional: true
       terser:
         optional: true
+
+  volar-service-css@0.0.62:
+    resolution: {integrity: sha512-JwNyKsH3F8PuzZYuqPf+2e+4CTU8YoyUHEHVnoXNlrLe7wy9U3biomZ56llN69Ris7TTy/+DEX41yVxQpM4qvg==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-emmet@0.0.62:
+    resolution: {integrity: sha512-U4dxWDBWz7Pi4plpbXf4J4Z/ss6kBO3TYrACxWNsE29abu75QzVS0paxDDhI6bhqpbDFXlpsDhZ9aXVFpnfGRQ==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-html@0.0.62:
+    resolution: {integrity: sha512-Zw01aJsZRh4GTGUjveyfEzEqpULQUdQH79KNEiKVYHZyuGtdBRYCHlrus1sueSNMxwwkuF5WnOHfvBzafs8yyQ==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-json@0.0.62:
+    resolution: {integrity: sha512-Ot+jP+/LzKcaGF7nzrn+gwpzAleb4ej5buO05M8KxfwfODte7o1blARKRoJ3Nv7ls0DBM38Dd5vjzvA9c/9Jtg==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-pug-beautify@0.0.62:
+    resolution: {integrity: sha512-dAFNuNEwTnnVthYoNJhoStwhf/PojzglwCrdhOb2nBegTG3xXMWRFmQzb0JfIlt2wq2wfUq5j+JJswgSD3KluQ==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-pug@0.0.62:
+    resolution: {integrity: sha512-C0/O8uGnRfijWKE0zFXxJ/o7BbLebzretsEaiMkvBDIxm5oe7HRDzQr6CgknV/WVgiohZ74v+0CwBPl2YmcPUQ==}
+
+  volar-service-typescript-twoslash-queries@0.0.62:
+    resolution: {integrity: sha512-KxFt4zydyJYYI0kFAcWPTh4u0Ha36TASPZkAnNY784GtgajerUqM80nX/W1d0wVhmcOFfAxkVsf/Ed+tiYU7ng==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-typescript@0.0.62:
+    resolution: {integrity: sha512-p7MPi71q7KOsH0eAbZwPBiKPp9B2+qrdHAd6VY5oTo9BUXatsOAdakTm9Yf0DUj6uWBAaOT01BSeVOPwucMV1g==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  vscode-css-languageservice@6.3.2:
+    resolution: {integrity: sha512-GEpPxrUTAeXWdZWHev1OJU9lz2Q2/PPBxQ2TIRmLGvQiH3WZbqaNoute0n0ewxlgtjzTW3AKZT+NHySk5Rf4Eg==}
+
+  vscode-html-languageservice@5.3.1:
+    resolution: {integrity: sha512-ysUh4hFeW/WOWz/TO9gm08xigiSsV/FOAZ+DolgJfeLftna54YdmZ4A+lIn46RbdO3/Qv5QHTn1ZGqmrXQhZyA==}
+
+  vscode-json-languageservice@5.4.2:
+    resolution: {integrity: sha512-2qujUseKRbLEwLXvEOFAxaz3y1ssdNCXXi95LRdG8AFchJHSnmI2qCg9ixoYxbJtSehIrXOmkhV87Y9lIivOgQ==}
+
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
+  vscode-nls@5.2.0:
+    resolution: {integrity: sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==}
+
+  vscode-uri@3.0.8:
+    resolution: {integrity: sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw==}
 
   vue-confetti@2.3.0:
     resolution: {integrity: sha512-zmPniVzBKv0ie/BEXBR6Isi08hYSd6lS18b8VduG5BzZ2tv6bO/rlwISg+IpGY2XsqAFTXFdTC28YR+UPocnAw==}
@@ -3027,7 +3306,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.24.1': {}
 
+  '@babel/helper-string-parser@7.25.9': {}
+
   '@babel/helper-validator-identifier@7.24.5': {}
+
+  '@babel/helper-validator-identifier@7.25.9': {}
 
   '@babel/highlight@7.24.5':
     dependencies:
@@ -3040,6 +3323,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.24.5
 
+  '@babel/parser@7.26.3':
+    dependencies:
+      '@babel/types': 7.26.3
+
   '@babel/runtime@7.24.5':
     dependencies:
       regenerator-runtime: 0.14.1
@@ -3049,6 +3336,11 @@ snapshots:
       '@babel/helper-string-parser': 7.24.1
       '@babel/helper-validator-identifier': 7.24.5
       to-fast-properties: 2.0.0
+
+  '@babel/types@7.26.3':
+    dependencies:
+      '@babel/helper-string-parser': 7.25.9
+      '@babel/helper-validator-identifier': 7.25.9
 
   '@d-fischer/cache-decorators@4.0.1':
     dependencies:
@@ -3169,6 +3461,29 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@emmetio/abbreviation@2.3.3':
+    dependencies:
+      '@emmetio/scanner': 1.0.4
+
+  '@emmetio/css-abbreviation@2.1.8':
+    dependencies:
+      '@emmetio/scanner': 1.0.4
+
+  '@emmetio/css-parser@0.4.0':
+    dependencies:
+      '@emmetio/stream-reader': 2.2.0
+      '@emmetio/stream-reader-utils': 0.1.0
+
+  '@emmetio/html-matcher@1.3.0':
+    dependencies:
+      '@emmetio/scanner': 1.0.4
+
+  '@emmetio/scanner@1.0.4': {}
+
+  '@emmetio/stream-reader-utils@0.1.0': {}
+
+  '@emmetio/stream-reader@2.2.0': {}
 
   '@emnapi/runtime@1.2.0':
     dependencies:
@@ -3456,6 +3771,8 @@ snapshots:
 
   '@img/sharp-win32-x64@0.33.4':
     optional: true
+
+  '@johnsoncodehk/pug-beautify@0.2.2': {}
 
   '@jridgewell/sourcemap-codec@1.4.15': {}
 
@@ -3751,14 +4068,62 @@ snapshots:
     dependencies:
       '@volar/source-map': 2.2.1
 
+  '@volar/language-core@2.4.11':
+    dependencies:
+      '@volar/source-map': 2.4.11
+
+  '@volar/language-server@2.4.11':
+    dependencies:
+      '@volar/language-core': 2.4.11
+      '@volar/language-service': 2.4.11
+      '@volar/typescript': 2.4.11
+      path-browserify: 1.0.1
+      request-light: 0.7.0
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.0.8
+
+  '@volar/language-service@2.4.11':
+    dependencies:
+      '@volar/language-core': 2.4.11
+      vscode-languageserver-protocol: 3.17.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.0.8
+
   '@volar/source-map@2.2.1':
     dependencies:
       muggle-string: 0.4.1
+
+  '@volar/source-map@2.4.11': {}
+
+  '@volar/test-utils@2.4.11':
+    dependencies:
+      '@volar/language-core': 2.4.11
+      '@volar/language-server': 2.4.11
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.0.8
 
   '@volar/typescript@2.2.1':
     dependencies:
       '@volar/language-core': 2.2.1
       path-browserify: 1.0.1
+
+  '@volar/typescript@2.4.11':
+    dependencies:
+      '@volar/language-core': 2.4.11
+      path-browserify: 1.0.1
+      vscode-uri: 3.0.8
+
+  '@vscode/emmet-helper@2.11.0':
+    dependencies:
+      emmet: 2.4.11
+      jsonc-parser: 2.3.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+      vscode-uri: 3.0.8
+
+  '@vscode/l10n@0.0.18': {}
 
   '@vue/compiler-core@3.4.27':
     dependencies:
@@ -3768,10 +4133,23 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.0
 
+  '@vue/compiler-core@3.5.13':
+    dependencies:
+      '@babel/parser': 7.26.3
+      '@vue/shared': 3.5.13
+      entities: 4.5.0
+      estree-walker: 2.0.2
+      source-map-js: 1.2.0
+
   '@vue/compiler-dom@3.4.27':
     dependencies:
       '@vue/compiler-core': 3.4.27
       '@vue/shared': 3.4.27
+
+  '@vue/compiler-dom@3.5.13':
+    dependencies:
+      '@vue/compiler-core': 3.5.13
+      '@vue/shared': 3.5.13
 
   '@vue/compiler-sfc@3.4.27':
     dependencies:
@@ -3790,6 +4168,11 @@ snapshots:
       '@vue/compiler-dom': 3.4.27
       '@vue/shared': 3.4.27
 
+  '@vue/compiler-vue2@2.7.16':
+    dependencies:
+      de-indent: 1.0.2
+      he: 1.2.0
+
   '@vue/devtools-api@6.6.1': {}
 
   '@vue/language-core@2.0.16(typescript@5.4.5)':
@@ -3803,6 +4186,57 @@ snapshots:
       vue-template-compiler: 2.7.16
     optionalDependencies:
       typescript: 5.4.5
+
+  '@vue/language-core@2.1.10(typescript@5.4.5)':
+    dependencies:
+      '@volar/language-core': 2.4.11
+      '@vue/compiler-dom': 3.5.13
+      '@vue/compiler-vue2': 2.7.16
+      '@vue/shared': 3.5.13
+      alien-signals: 0.2.2
+      minimatch: 9.0.4
+      muggle-string: 0.4.1
+      path-browserify: 1.0.1
+    optionalDependencies:
+      typescript: 5.4.5
+
+  '@vue/language-server@2.1.10(typescript@5.4.5)':
+    dependencies:
+      '@volar/language-core': 2.4.11
+      '@volar/language-server': 2.4.11
+      '@volar/test-utils': 2.4.11
+      '@vue/language-core': 2.1.10(typescript@5.4.5)
+      '@vue/language-service': 2.1.10(typescript@5.4.5)
+      '@vue/typescript-plugin': 2.1.10(typescript@5.4.5)
+      vscode-languageserver-protocol: 3.17.5
+      vscode-uri: 3.0.8
+    transitivePeerDependencies:
+      - typescript
+
+  '@vue/language-service@2.1.10(typescript@5.4.5)':
+    dependencies:
+      '@volar/language-core': 2.4.11
+      '@volar/language-service': 2.4.11
+      '@volar/typescript': 2.4.11
+      '@vue/compiler-dom': 3.5.13
+      '@vue/language-core': 2.1.10(typescript@5.4.5)
+      '@vue/shared': 3.5.13
+      '@vue/typescript-plugin': 2.1.10(typescript@5.4.5)
+      alien-signals: 0.2.2
+      path-browserify: 1.0.1
+      volar-service-css: 0.0.62(@volar/language-service@2.4.11)
+      volar-service-emmet: 0.0.62(@volar/language-service@2.4.11)
+      volar-service-html: 0.0.62(@volar/language-service@2.4.11)
+      volar-service-json: 0.0.62(@volar/language-service@2.4.11)
+      volar-service-pug: 0.0.62
+      volar-service-pug-beautify: 0.0.62(@volar/language-service@2.4.11)
+      volar-service-typescript: 0.0.62(@volar/language-service@2.4.11)
+      volar-service-typescript-twoslash-queries: 0.0.62(@volar/language-service@2.4.11)
+      vscode-html-languageservice: 5.3.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.0.8
+    transitivePeerDependencies:
+      - typescript
 
   '@vue/reactivity@3.4.27':
     dependencies:
@@ -3827,7 +4261,17 @@ snapshots:
 
   '@vue/shared@3.4.27': {}
 
+  '@vue/shared@3.5.13': {}
+
   '@vue/tsconfig@0.5.1': {}
+
+  '@vue/typescript-plugin@2.1.10(typescript@5.4.5)':
+    dependencies:
+      '@volar/typescript': 2.4.11
+      '@vue/language-core': 2.1.10(typescript@5.4.5)
+      '@vue/shared': 3.5.13
+    transitivePeerDependencies:
+      - typescript
 
   '@vueuse/core@10.9.0(vue@3.4.27(typescript@5.4.5))':
     dependencies:
@@ -3879,6 +4323,8 @@ snapshots:
     dependencies:
       acorn: 8.11.3
 
+  acorn@7.4.1: {}
+
   acorn@8.11.3: {}
 
   agent-base@6.0.2:
@@ -3908,6 +4354,8 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  alien-signals@0.2.2: {}
 
   ansi-regex@5.0.1: {}
 
@@ -4010,6 +4458,11 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  call-bind-apply-helpers@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
   call-bind@1.0.7:
     dependencies:
       es-define-property: 1.0.0
@@ -4017,6 +4470,11 @@ snapshots:
       function-bind: 1.1.2
       get-intrinsic: 1.2.4
       set-function-length: 1.2.2
+
+  call-bound@1.0.3:
+    dependencies:
+      call-bind-apply-helpers: 1.0.1
+      get-intrinsic: 1.2.6
 
   callsites@3.1.0: {}
 
@@ -4043,6 +4501,10 @@ snapshots:
       supports-color: 7.2.0
 
   chalk@5.3.0: {}
+
+  character-parser@2.2.0:
+    dependencies:
+      is-regex: 1.2.1
 
   cheminfo-types@1.7.3: {}
 
@@ -4254,9 +4716,20 @@ snapshots:
 
   dotenv@16.4.5: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   ee-first@1.1.1: {}
 
   efrt-unpack@2.2.0: {}
+
+  emmet@2.4.11:
+    dependencies:
+      '@emmetio/abbreviation': 2.3.3
+      '@emmetio/css-abbreviation': 2.1.8
 
   emoji-regex@8.0.0: {}
 
@@ -4303,7 +4776,13 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.4
 
+  es-define-property@1.0.1: {}
+
   es-errors@1.3.0: {}
+
+  es-object-atoms@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.20.2:
     optionalDependencies:
@@ -4599,6 +5078,19 @@ snapshots:
       has-symbols: 1.0.3
       hasown: 2.0.2
 
+  get-intrinsic@1.2.6:
+    dependencies:
+      call-bind-apply-helpers: 1.0.1
+      dunder-proto: 1.0.1
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.0.0
+      function-bind: 1.1.2
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.0.0
+
   get-tsconfig@4.8.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -4647,6 +5139,8 @@ snapshots:
     dependencies:
       get-intrinsic: 1.2.4
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   graphemer@1.4.0: {}
@@ -4678,6 +5172,12 @@ snapshots:
   has-proto@1.0.3: {}
 
   has-symbols@1.0.3: {}
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.0.3
 
   has-unicode@2.0.1: {}
 
@@ -4805,6 +5305,11 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
+  is-expression@4.0.0:
+    dependencies:
+      acorn: 7.4.1
+      object-assign: 4.1.1
+
   is-extglob@2.1.1: {}
 
   is-finite@1.1.0: {}
@@ -4826,6 +5331,13 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-plain-obj@1.1.0: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.3
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.2
 
   is-unicode-supported@0.1.0: {}
 
@@ -4856,6 +5368,10 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  jsonc-parser@2.3.1: {}
+
+  jsonc-parser@3.3.1: {}
 
   junk@4.0.1: {}
 
@@ -4918,6 +5434,8 @@ snapshots:
   map-obj@4.3.0: {}
 
   marked@12.0.2: {}
+
+  math-intrinsics@1.0.0: {}
 
   media-typer@0.3.0: {}
 
@@ -5348,6 +5866,19 @@ snapshots:
 
   pstree.remy@1.1.8: {}
 
+  pug-error@2.1.0: {}
+
+  pug-lexer@5.0.1:
+    dependencies:
+      character-parser: 2.2.0
+      is-expression: 4.0.0
+      pug-error: 2.1.0
+
+  pug-parser@6.0.0:
+    dependencies:
+      pug-error: 2.1.0
+      token-stream: 1.0.0
+
   punycode@2.3.1: {}
 
   qs@6.11.0:
@@ -5399,6 +5930,8 @@ snapshots:
 
   regexp-to-ast@0.4.0:
     optional: true
+
+  request-light@0.7.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -5476,6 +6009,8 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.6.1: {}
+
+  semver@7.6.3: {}
 
   send@0.18.0:
     dependencies:
@@ -5710,6 +6245,8 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  token-stream@1.0.0: {}
+
   touch@3.1.0:
     dependencies:
       nopt: 1.0.10
@@ -5752,6 +6289,10 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
+  typescript-auto-import-cache@0.3.5:
+    dependencies:
+      semver: 7.6.3
+
   typescript-eslint@7.8.0(eslint@8.57.0)(typescript@5.4.5):
     dependencies:
       '@typescript-eslint/eslint-plugin': 7.8.0(@typescript-eslint/parser@7.8.0(eslint@8.57.0)(typescript@5.4.5))(eslint@8.57.0)(typescript@5.4.5)
@@ -5785,7 +6326,7 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-vue-components@0.26.0(@babel/parser@7.24.5)(rollup@4.17.2)(vue@3.4.27(typescript@5.4.5)):
+  unplugin-vue-components@0.26.0(@babel/parser@7.26.3)(rollup@4.17.2)(vue@3.4.27(typescript@5.4.5)):
     dependencies:
       '@antfu/utils': 0.7.7
       '@rollup/pluginutils': 5.1.0(rollup@4.17.2)
@@ -5799,7 +6340,7 @@ snapshots:
       unplugin: 1.10.1
       vue: 3.4.27(typescript@5.4.5)
     optionalDependencies:
-      '@babel/parser': 7.24.5
+      '@babel/parser': 7.26.3
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -5834,6 +6375,112 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.5.5
       fsevents: 2.3.3
+
+  volar-service-css@0.0.62(@volar/language-service@2.4.11):
+    dependencies:
+      vscode-css-languageservice: 6.3.2
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.0.8
+    optionalDependencies:
+      '@volar/language-service': 2.4.11
+
+  volar-service-emmet@0.0.62(@volar/language-service@2.4.11):
+    dependencies:
+      '@emmetio/css-parser': 0.4.0
+      '@emmetio/html-matcher': 1.3.0
+      '@vscode/emmet-helper': 2.11.0
+      vscode-uri: 3.0.8
+    optionalDependencies:
+      '@volar/language-service': 2.4.11
+
+  volar-service-html@0.0.62(@volar/language-service@2.4.11):
+    dependencies:
+      vscode-html-languageservice: 5.3.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.0.8
+    optionalDependencies:
+      '@volar/language-service': 2.4.11
+
+  volar-service-json@0.0.62(@volar/language-service@2.4.11):
+    dependencies:
+      vscode-json-languageservice: 5.4.2
+      vscode-uri: 3.0.8
+    optionalDependencies:
+      '@volar/language-service': 2.4.11
+
+  volar-service-pug-beautify@0.0.62(@volar/language-service@2.4.11):
+    dependencies:
+      '@johnsoncodehk/pug-beautify': 0.2.2
+    optionalDependencies:
+      '@volar/language-service': 2.4.11
+
+  volar-service-pug@0.0.62:
+    dependencies:
+      '@volar/language-service': 2.4.11
+      muggle-string: 0.4.1
+      pug-lexer: 5.0.1
+      pug-parser: 6.0.0
+      volar-service-html: 0.0.62(@volar/language-service@2.4.11)
+      vscode-html-languageservice: 5.3.1
+      vscode-languageserver-textdocument: 1.0.12
+
+  volar-service-typescript-twoslash-queries@0.0.62(@volar/language-service@2.4.11):
+    dependencies:
+      vscode-uri: 3.0.8
+    optionalDependencies:
+      '@volar/language-service': 2.4.11
+
+  volar-service-typescript@0.0.62(@volar/language-service@2.4.11):
+    dependencies:
+      path-browserify: 1.0.1
+      semver: 7.6.3
+      typescript-auto-import-cache: 0.3.5
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-nls: 5.2.0
+      vscode-uri: 3.0.8
+    optionalDependencies:
+      '@volar/language-service': 2.4.11
+
+  vscode-css-languageservice@6.3.2:
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+      vscode-uri: 3.0.8
+
+  vscode-html-languageservice@5.3.1:
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+      vscode-uri: 3.0.8
+
+  vscode-json-languageservice@5.4.2:
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      jsonc-parser: 3.3.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+      vscode-uri: 3.0.8
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+
+  vscode-nls@5.2.0: {}
+
+  vscode-uri@3.0.8: {}
 
   vue-confetti@2.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^0.37.79
         version: 0.37.83
       discord.js:
-        specifier: ^14.15.2
-        version: 14.15.2
+        specifier: 14.17.0
+        version: 14.17.0
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -294,20 +294,20 @@ packages:
   '@d-fischer/typed-event-emitter@3.3.3':
     resolution: {integrity: sha512-OvSEOa8icfdWDqcRtjSEZtgJTFOFNgTjje7zaL0+nAtu2/kZtRCSK5wUMrI/aXtCH8o0Qz2vA8UqkhWUTARFQQ==}
 
-  '@discordjs/builders@1.8.1':
-    resolution: {integrity: sha512-GkF+HM01FHy+NSoTaUPR8z44otfQgJ1AIsRxclYGUZDyUbdZEFyD/5QVv2Y1Flx6M+B0bQLzg2M9CJv5lGTqpA==}
+  '@discordjs/builders@1.10.0':
+    resolution: {integrity: sha512-ikVZsZP+3shmVJ5S1oM+7SveUCK3L9fTyfA8aJ7uD9cNQlTqF+3Irbk2Y22KXTb3C3RNUahRkSInClJMkHrINg==}
     engines: {node: '>=16.11.0'}
 
   '@discordjs/collection@1.5.3':
     resolution: {integrity: sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==}
     engines: {node: '>=16.11.0'}
 
-  '@discordjs/collection@2.1.0':
-    resolution: {integrity: sha512-mLcTACtXUuVgutoznkh6hS3UFqYirDYAg5Dc1m8xn6OvPjetnUlf/xjtqnnc47OwWdaoCQnHmHh9KofhD6uRqw==}
+  '@discordjs/collection@2.1.1':
+    resolution: {integrity: sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==}
     engines: {node: '>=18'}
 
-  '@discordjs/formatters@0.4.0':
-    resolution: {integrity: sha512-fJ06TLC1NiruF35470q3Nr1bi95BdvKFAF+T5bNfZJ4bNdqZ3VZ+Ttg6SThqTxm6qumSG3choxLBHMC69WXNXQ==}
+  '@discordjs/formatters@0.6.0':
+    resolution: {integrity: sha512-YIruKw4UILt/ivO4uISmrGq2GdMY6EkoTtD0oS0GvkJFRZbTSdPhzYiUILbJ/QslsvC9H9nTgGgnarnIl4jMfw==}
     engines: {node: '>=16.11.0'}
 
   '@discordjs/node-pre-gyp@0.4.5':
@@ -318,20 +318,20 @@ packages:
     resolution: {integrity: sha512-NEE76A96FtQ5YuoAVlOlB3ryMPrkXbUCTQICHGKb8ShtjXyubGicjRMouHtP1RpuDdm16cDa+oI3aAMo1zQRUQ==}
     engines: {node: '>=12.0.0'}
 
-  '@discordjs/rest@2.3.0':
-    resolution: {integrity: sha512-C1kAJK8aSYRv3ZwMG8cvrrW4GN0g5eMdP8AuN8ODH5DyOCbHgJspze1my3xHOAgwLJdKUbWNVyAeJ9cEdduqIg==}
-    engines: {node: '>=16.11.0'}
+  '@discordjs/rest@2.4.1':
+    resolution: {integrity: sha512-a4Vv69usWY4ypwcENzH6QWYNrPwu+es3tRQMLKgaUFs0Mx2Yn7xfDW62++kcgckG8XbHWO7ej1x7raS7LuYgvA==}
+    engines: {node: '>=18'}
 
-  '@discordjs/util@1.1.0':
-    resolution: {integrity: sha512-IndcI5hzlNZ7GS96RV3Xw1R2kaDuXEp7tRIy/KlhidpN/BQ1qh1NZt3377dMLTa44xDUNKT7hnXkA/oUAzD/lg==}
-    engines: {node: '>=16.11.0'}
+  '@discordjs/util@1.1.1':
+    resolution: {integrity: sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==}
+    engines: {node: '>=18'}
 
   '@discordjs/voice@0.17.0':
     resolution: {integrity: sha512-hArn9FF5ZYi1IkxdJEVnJi+OxlwLV0NJYWpKXsmNOojtGtAZHxmsELA+MZlu2KW1F/K1/nt7lFOfcMXNYweq9w==}
     engines: {node: '>=16.11.0'}
 
-  '@discordjs/ws@1.1.0':
-    resolution: {integrity: sha512-O97DIeSvfNTn5wz5vaER6ciyUsr7nOqSEtsLoMhhIgeFkhnxLRqSr00/Fpq2/ppLgjDGLbQCDzIK7ilGoB/M7A==}
+  '@discordjs/ws@1.2.0':
+    resolution: {integrity: sha512-QH5CAFe3wHDiedbO+EI3OOiyipwWd+Q6BdoFZUw/Wf2fw5Cv2fgU/9UEtJRmJa9RecI+TAhdGPadMaEIur5yJg==}
     engines: {node: '>=16.11.0'}
 
   '@emmetio/abbreviation@2.3.3':
@@ -924,12 +924,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@sapphire/async-queue@1.5.2':
-    resolution: {integrity: sha512-7X7FFAA4DngXUl95+hYbUF19bp1LGiffjJtu7ygrZrbdCSsdDDBaSjB7Akw0ZbOu6k0xpXyljnJ6/RZUvLfRdg==}
+  '@sapphire/async-queue@1.5.5':
+    resolution: {integrity: sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
 
-  '@sapphire/shapeshift@3.9.7':
-    resolution: {integrity: sha512-4It2mxPSr4OGn4HSQWGmhFMsNFGfFVhWeRPCRwbH972Ek2pzfGRZtb0pJ4Ze6oIzcyh2jw7nUDa6qGlWofgd9g==}
+  '@sapphire/shapeshift@4.0.0':
+    resolution: {integrity: sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==}
     engines: {node: '>=v16'}
 
   '@sapphire/snowflake@3.5.3':
@@ -1086,8 +1086,8 @@ packages:
       vite: ^5.0.0
       vue: ^3.2.25
 
-  '@vladfrangu/async_event_emitter@2.2.4':
-    resolution: {integrity: sha512-ButUPz9E9cXMLgvAW8aLAKKJJsPu1dY1/l/E8xzLFuysowXygs6GBcyunK9rnGC4zTsnIc2mQo71rGw9U+Ykug==}
+  '@vladfrangu/async_event_emitter@2.4.6':
+    resolution: {integrity: sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==}
     engines: {node: '>=v14.0.0', npm: '>=7.0.0'}
 
   '@volar/language-core@2.2.1':
@@ -1581,12 +1581,15 @@ packages:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
 
+  discord-api-types@0.37.114:
+    resolution: {integrity: sha512-9b9oOpktWSmE6ooToc46wfw151SHC/+idmnZvtwpEzW85BijUspQxj4W2uOmo+nZVTdEyb3fku58k+4rHKpdSQ==}
+
   discord-api-types@0.37.83:
     resolution: {integrity: sha512-urGGYeWtWNYMKnYlZnOnDHm8fVRffQs3U0SpE8RHeiuLKb/u92APS8HoQnPTFbnXmY1vVnXjXO4dOxcAn3J+DA==}
 
-  discord.js@14.15.2:
-    resolution: {integrity: sha512-wGD37YCaTUNprtpqMIRuNiswwsvSWXrHykBSm2SAosoTYut0VUDj9yo9t4iLtMKvuhI49zYkvKc2TNdzdvpJhg==}
-    engines: {node: '>=16.11.0'}
+  discord.js@14.17.0:
+    resolution: {integrity: sha512-bK6oee/RBZF/LCPnR4afECsJV5voUVmfDmOHAMJSJeDeR42EkVyZJN3QVp1Uo0c3/OG0Z6vQVveY4+tFaMO4og==}
+    engines: {node: '>=18'}
 
   doctrine@3.0.0:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
@@ -2940,6 +2943,9 @@ packages:
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tsx@4.19.1:
     resolution: {integrity: sha512-0flMz1lh74BR4wOvBjuh9olbnwqCPc35OOlfyzHba0Dc+QNUeWX/Gq2YTbnwcWPO3BMd8fkzRVrHcsR+a7z7rA==}
     engines: {node: '>=18.0.0'}
@@ -2995,9 +3001,9 @@ packages:
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
-  undici@6.13.0:
-    resolution: {integrity: sha512-Q2rtqmZWrbP8nePMq7mOJIN98M0fYvSgV89vwl/BQRT4mDOeY2GXZngfGpcBBhtky3woM7G24wZV3Q304Bv6cw==}
-    engines: {node: '>=18.0'}
+  undici@6.19.8:
+    resolution: {integrity: sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==}
+    engines: {node: '>=18.17'}
 
   unhead@1.9.10:
     resolution: {integrity: sha512-Y3w+j1x1YFig2YuE+W2sER+SciRR7MQktYRHNqvZJ0iUNCCJTS8Z/SdSMUEeuFV28daXeASlR3fy7Ry3O2indg==}
@@ -3377,23 +3383,23 @@ snapshots:
     dependencies:
       tslib: 2.6.2
 
-  '@discordjs/builders@1.8.1':
+  '@discordjs/builders@1.10.0':
     dependencies:
-      '@discordjs/formatters': 0.4.0
-      '@discordjs/util': 1.1.0
-      '@sapphire/shapeshift': 3.9.7
-      discord-api-types: 0.37.83
+      '@discordjs/formatters': 0.6.0
+      '@discordjs/util': 1.1.1
+      '@sapphire/shapeshift': 4.0.0
+      discord-api-types: 0.37.114
       fast-deep-equal: 3.1.3
       ts-mixer: 6.0.4
-      tslib: 2.6.2
+      tslib: 2.8.1
 
   '@discordjs/collection@1.5.3': {}
 
-  '@discordjs/collection@2.1.0': {}
+  '@discordjs/collection@2.1.1': {}
 
-  '@discordjs/formatters@0.4.0':
+  '@discordjs/formatters@0.6.0':
     dependencies:
-      discord-api-types: 0.37.83
+      discord-api-types: 0.37.114
 
   '@discordjs/node-pre-gyp@0.4.5':
     dependencies:
@@ -3418,19 +3424,19 @@ snapshots:
       - encoding
       - supports-color
 
-  '@discordjs/rest@2.3.0':
+  '@discordjs/rest@2.4.1':
     dependencies:
-      '@discordjs/collection': 2.1.0
-      '@discordjs/util': 1.1.0
-      '@sapphire/async-queue': 1.5.2
+      '@discordjs/collection': 2.1.1
+      '@discordjs/util': 1.1.1
+      '@sapphire/async-queue': 1.5.5
       '@sapphire/snowflake': 3.5.3
-      '@vladfrangu/async_event_emitter': 2.2.4
-      discord-api-types: 0.37.83
+      '@vladfrangu/async_event_emitter': 2.4.6
+      discord-api-types: 0.37.114
       magic-bytes.js: 1.10.0
-      tslib: 2.6.2
-      undici: 6.13.0
+      tslib: 2.8.1
+      undici: 6.19.8
 
-  '@discordjs/util@1.1.0': {}
+  '@discordjs/util@1.1.1': {}
 
   '@discordjs/voice@0.17.0(@discordjs/opus@0.9.0)':
     dependencies:
@@ -3447,16 +3453,16 @@ snapshots:
       - opusscript
       - utf-8-validate
 
-  '@discordjs/ws@1.1.0':
+  '@discordjs/ws@1.2.0':
     dependencies:
-      '@discordjs/collection': 2.1.0
-      '@discordjs/rest': 2.3.0
-      '@discordjs/util': 1.1.0
-      '@sapphire/async-queue': 1.5.2
+      '@discordjs/collection': 2.1.1
+      '@discordjs/rest': 2.4.1
+      '@discordjs/util': 1.1.1
+      '@sapphire/async-queue': 1.5.5
       '@types/ws': 8.5.10
-      '@vladfrangu/async_event_emitter': 2.2.4
-      discord-api-types: 0.37.83
-      tslib: 2.6.2
+      '@vladfrangu/async_event_emitter': 2.4.6
+      discord-api-types: 0.37.114
+      tslib: 2.8.1
       ws: 8.17.0
     transitivePeerDependencies:
       - bufferutil
@@ -3848,9 +3854,9 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.17.2':
     optional: true
 
-  '@sapphire/async-queue@1.5.2': {}
+  '@sapphire/async-queue@1.5.5': {}
 
-  '@sapphire/shapeshift@3.9.7':
+  '@sapphire/shapeshift@4.0.0':
     dependencies:
       fast-deep-equal: 3.1.3
       lodash: 4.17.21
@@ -4062,7 +4068,7 @@ snapshots:
       vite: 5.2.11(@types/node@22.5.5)
       vue: 3.4.27(typescript@5.4.5)
 
-  '@vladfrangu/async_event_emitter@2.2.4': {}
+  '@vladfrangu/async_event_emitter@2.4.6': {}
 
   '@volar/language-core@2.2.1':
     dependencies:
@@ -4670,22 +4676,24 @@ snapshots:
     dependencies:
       path-type: 4.0.0
 
+  discord-api-types@0.37.114: {}
+
   discord-api-types@0.37.83: {}
 
-  discord.js@14.15.2:
+  discord.js@14.17.0:
     dependencies:
-      '@discordjs/builders': 1.8.1
+      '@discordjs/builders': 1.10.0
       '@discordjs/collection': 1.5.3
-      '@discordjs/formatters': 0.4.0
-      '@discordjs/rest': 2.3.0
-      '@discordjs/util': 1.1.0
-      '@discordjs/ws': 1.1.0
+      '@discordjs/formatters': 0.6.0
+      '@discordjs/rest': 2.4.1
+      '@discordjs/util': 1.1.1
+      '@discordjs/ws': 1.2.0
       '@sapphire/snowflake': 3.5.3
-      discord-api-types: 0.37.83
+      discord-api-types: 0.37.114
       fast-deep-equal: 3.1.3
       lodash.snakecase: 4.1.1
-      tslib: 2.6.2
-      undici: 6.13.0
+      tslib: 2.8.1
+      undici: 6.19.8
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -6263,6 +6271,8 @@ snapshots:
 
   tslib@2.6.2: {}
 
+  tslib@2.8.1: {}
+
   tsx@4.19.1:
     dependencies:
       esbuild: 0.23.1
@@ -6310,7 +6320,7 @@ snapshots:
 
   undici-types@6.19.8: {}
 
-  undici@6.13.0: {}
+  undici@6.19.8: {}
 
   unhead@1.9.10:
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,7 @@
     "chalk": "^5.3.0",
     "cors": "^2.8.5",
     "discord-api-types": "^0.37.79",
-    "discord.js": "^14.15.2",
+    "discord.js": "14.17.0",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "libsodium-wrappers": "^0.7.10",

--- a/server/src/action-utils/action-manager-models.js
+++ b/server/src/action-utils/action-manager-models.js
@@ -33,6 +33,7 @@ export class Action {
      * @param {string[]} auth
      * @param {string[]} requiredParams
      * @param {string[]} optionalParams
+     * @param {function} registerFunction
      */
     constructor({
         key,

--- a/server/src/action-utils/action-manager-models.js
+++ b/server/src/action-utils/action-manager-models.js
@@ -75,7 +75,7 @@ export class Action {
             get: (...args) => Cache.get(...args),
             createRecord: (tableName, data) => createRecord(Cache, tableName, [data]),
             createRecords: (tableName, items) => createRecord(Cache, tableName, items),
-            updateRecord: (tableName, item, data, source) => updateRecord(Cache, tableName, item, data, source),
+            updateRecord: (tableName, item, data, source) => updateRecord(Cache, tableName, item, data, source || `actions/${this.key}`),
             auth: Cache.auth,
             permissions
         };

--- a/server/src/action-utils/action-utils.js
+++ b/server/src/action-utils/action-utils.js
@@ -363,7 +363,7 @@ export async function checkDeleteMessage(mapObject, keyPrefix) {
     if (mapObject.get(`${keyPrefix}_message_id`) && mapObject.get(`${keyPrefix}_channel_id`)) {
         try {
             const channel = await client.channels.fetch(mapObject.get(`${keyPrefix}_channel_id`));
-            if (channel?.isTextBased()) await channel.messages.delete(mapObject.get(`${keyPrefix}_message_id`));
+            if (channel?.isSendable()) await channel.messages.delete(mapObject.get(`${keyPrefix}_message_id`));
         } catch (e) {
             console.error(`Error trying to delete ${keyPrefix} message`, e);
         } finally {
@@ -399,7 +399,7 @@ export async function sendMessage({
         return mapObject;
     }
     const channel = await client.channels.fetch(channelID);
-    if (channel?.isTextBased()) {
+    if (channel?.isSendable()) {
         try {
             const message = await channel.send(content);
             mapObject.push(`${key}_channel_id`, channel.id);

--- a/server/src/action-utils/action-utils.js
+++ b/server/src/action-utils/action-utils.js
@@ -227,7 +227,7 @@ export async function getMatchScoreReporting(matchID) {
 /**
  *
  * @param matchID
- * @param {boolean} excludeCompleted
+ * @param { {excludeCompleted: Boolean } } settings
  * @returns {Promise<({report: Report | undefined, match: Match})>}
  */
 export async function getMatchRescheduling(matchID, { excludeCompleted } = {}) {

--- a/server/src/action-utils/action-utils.js
+++ b/server/src/action-utils/action-utils.js
@@ -227,6 +227,7 @@ export async function getMatchScoreReporting(matchID) {
 /**
  *
  * @param matchID
+ * @param {boolean} excludeCompleted
  * @returns {Promise<({report: Report | undefined, match: Match})>}
  */
 export async function getMatchRescheduling(matchID, { excludeCompleted } = {}) {
@@ -264,6 +265,7 @@ export async function getTwitchAPIClient(channel) {
     if (!channel) throw("Internal error connecting to Twitch");
     try {
         const accessToken = await Cache.auth.getTwitchAccessToken(channel);
+        // this warning is because the twitch auth data is thrown into the general auth map but it shouldn't actually cause an error here
         const authProvider = new StaticAuthProvider(process.env.TWITCH_CLIENT_ID, accessToken);
         return new ApiClient({authProvider});
     } catch (e) {

--- a/server/src/action-utils/ts-action-utils.ts
+++ b/server/src/action-utils/ts-action-utils.ts
@@ -1,9 +1,10 @@
+import type { Snowflake } from "discord-api-types/globals";
 import { Match } from "../types.js";
 import { get } from "./action-cache.js";
 import { MapObject } from "../discord/managers.js";
 import client from "../discord/client.js";
-import { Guild } from "discord.js";
-import { cleanID } from "./action-utils.js";
+import { ChannelType, Guild, MessageCreateOptions, MessagePayload } from "discord.js";
+import { cleanID, sendMessage } from "./action-utils.js";
 
 
 export async function generateMatchReportText(match: Match) {
@@ -126,9 +127,19 @@ export async function generateMatchReportText(match: Match) {
                 mapLine.push(map.replay_code);
             }
 
-
             lines.push(mapLine.join(" - "));
 
+            if (map.team_1_picks?.length || map.team_2_picks?.length) {
+                const teamPicks = [];
+
+                for (const teamI of [0, 1]) {
+                    const team = teams[teamI];
+                    const bannedHeroes = await Promise.all(([map.team_1_picks, map.team_2_picks][teamI] || []).map(id => get(id)));
+                    teamPicks.push(`${team.code || team.name} ban: ${bannedHeroes.map(hero => hero.icon_emoji_text || hero.name).join(" ")}`);
+                }
+
+                lines.push(`Picks: ${teamPicks.join(" / ")}`);
+            }
             if (map.team_1_bans?.length || map.team_2_bans?.length) {
                 const teamBans = [];
 
@@ -138,8 +149,16 @@ export async function generateMatchReportText(match: Match) {
                     teamBans.push(`${team.code || team.name} ban: ${bannedHeroes.map(hero => hero.icon_emoji_text || hero.name).join(" ")}`);
                 }
 
-                lines.push(`> ${teamBans.join(" | ")}`);
+                const banCount = (map.team_1_bans?.length || 0) + (map.team_2_bans?.length || 0);
+                // if there are only 2 bans and no picks, add to the current line
+                if (banCount <= 2 && !map.team_1_picks?.length && !map.team_2_picks?.length) {
+                    lines[lines.length - 1] += ` - Bans: ${teamBans.join(" / ")}`;
+                } else {
+                    lines.push(`Bans: ${teamBans.join(" / ")}`);
+                }
+
             }
+
         }
 
 
@@ -149,4 +168,49 @@ export async function generateMatchReportText(match: Match) {
         console.error("Error generating match report text", e);
         return null;
     }
+}
+
+export async function checkDeleteMessage<KeyType extends string>(mapObject: MapObject, keyPrefix: KeyType) {
+    if (mapObject.get(`${keyPrefix}_message_id`) && mapObject.get(`${keyPrefix}_channel_id`)) {
+        try {
+            const channel = await client.channels.fetch(mapObject.get(`${keyPrefix}_channel_id`));
+            if (channel) {
+                console.log(`${keyPrefix} - ${channel.id} ${channel.type !== ChannelType.DM ? channel.name : ""}`);
+            } else {
+                console.warn(`${keyPrefix} - No channel`);
+            }
+            if (channel?.isTextBased()) await channel.messages.delete(mapObject.get(`${keyPrefix}_message_id`));
+        } catch (e) {
+            console.error(`Error trying to delete ${keyPrefix} message`, e);
+        } finally {
+            mapObject.push(`${keyPrefix}_message_id`, null);
+            mapObject.push(`${keyPrefix}_channel_id`, null);
+        }
+    }
+}
+
+export async function looseDeleteRecordedMessage<KeyType extends string>(mapObject: MapObject, keyPrefix: KeyType) {
+    console.log("Loose delete", mapObject.data, keyPrefix);
+    await checkDeleteMessage(mapObject, keyPrefix);
+    return mapObject;
+}
+export async function looseDeleteRecordedMessages<KeyType extends string>(mapObject: MapObject, keyPrefixes: KeyType[]) {
+    console.log("Loose delete multiple", mapObject.data, keyPrefixes);
+    if (!mapObject?.data) return mapObject;
+    console.log(mapObject.data);
+    await Promise.all(keyPrefixes.map(async keyPrefix => checkDeleteMessage(mapObject, keyPrefix)));
+    return mapObject;
+}
+
+export async function sendRecordedMessage<KeyType extends string>({ key, mapObject, channelID, content, success } :
+    {
+        key: KeyType;
+        mapObject: MapObject;
+        channelID?: Snowflake;
+        content?: null | string | MessagePayload | MessageCreateOptions;
+        success?: (updatedMapObject: MapObject) => void;
+    }
+): Promise<MapObject> {
+    console.log("Recorded message", key, mapObject.data);
+    return sendMessage({ key, mapObject, channelID, content, success });
 }

--- a/server/src/action-utils/ts-action-utils.ts
+++ b/server/src/action-utils/ts-action-utils.ts
@@ -179,7 +179,7 @@ export async function checkDeleteMessage<KeyType extends string>(mapObject: MapO
             } else {
                 console.warn(`${keyPrefix} - No channel`);
             }
-            if (channel?.isTextBased()) await channel.messages.delete(mapObject.get(`${keyPrefix}_message_id`));
+            if (channel?.isSendable()) await channel.messages.delete(mapObject.get(`${keyPrefix}_message_id`));
         } catch (e) {
             console.error(`Error trying to delete ${keyPrefix} message`, e);
         } finally {

--- a/server/src/actions/approve-match-reschedule.ts
+++ b/server/src/actions/approve-match-reschedule.ts
@@ -1,0 +1,79 @@
+import { ActionAuth, Match, MatchResolvableID, Report } from "../types.js";
+import { cleanID, dirtyID, getMatchRescheduling, looseDeleteMessage } from "../action-utils/action-utils.js";
+import { Action } from "../action-utils/action-manager-models.js";
+import { get } from "../action-utils/action-cache.js";
+import { MapObject } from "../discord/managers.js";
+
+export default {
+    key: "approve-match-reschedule",
+    requiredParams: ["matchID", "reaction"],
+    auth: ["user"],
+    async handler(
+        {matchID, reaction}: { matchID: MatchResolvableID, reaction: "approve" | "deny" | "delete" },
+        {user}: ActionAuth
+    ) {
+        const {match, report}: { match: Match, report: Report | undefined } = await getMatchRescheduling(matchID);
+        if (!report) {
+            throw "There is no reschedule request on this match";
+        }
+
+        const teams = await Promise.all((match.teams || []).map(t => get(t)));
+
+        const reportableTeams = teams.filter(t => {
+            // if (reaction === "counter-approve" || reaction === "counter-deny") {
+            //     // original team
+            //     return cleanID(t.id) === cleanID(report.team?.[0]);
+            // }
+            return cleanID(t.id) !== cleanID(report.team?.[0]);
+        });
+
+        const actingTeam = reportableTeams.find(team => [
+            ...(team.players || []),
+            ...(team.captains || []),
+            ...(team.staff || []),
+            ...(team.owners || []),
+        ].includes(dirtyID(user.airtable.id)));
+
+        const isRelated = teams.some(team => [
+            ...(team.players || []),
+            ...(team.captains || []),
+            ...(team.staff || []),
+            ...(team.owners || []),
+        ].includes(dirtyID(user.airtable.id)));
+
+        if (!isRelated) throw "You don't have permission to use rescheduling for this match";
+
+        if (reaction === "approve") {
+            if (!actingTeam) throw "You don't have permission to approve this request";
+            let messageData = new MapObject(report.message_data);
+            messageData = await looseDeleteMessage(messageData, "opponent_reschedule_request");
+
+            await this.helpers.updateRecord("Reports", report, {
+                "Approved by opponent": true,
+                "Log": (report.log ? report.log + "\n" : "") + `${(new Date()).toLocaleString()}: ${user.airtable.name} approved reschedule request as ${actingTeam?.name}`,
+                "Message Data": messageData.textMap
+            });
+        } else if (reaction === "deny") {
+            if (!actingTeam) throw "You don't have permission to approve this request";
+            let messageData = new MapObject(report.message_data);
+            messageData = await looseDeleteMessage(messageData, "opponent_reschedule_request");
+
+            await this.helpers.updateRecord("Reports", report, {
+                "Denied by opponent": true,
+                "Log": (report.log ? report.log + "\n" : "") + `${(new Date()).toLocaleString()}: ${user.airtable.name} denied reschedule request as ${actingTeam?.name}`,
+                "Message Data": messageData.textMap
+            });
+
+        } else if (reaction === "delete") {
+            if ((report.approved || report.denied_by_opponent) && !report.denied_by_staff) {
+                // Finished report or opponent denial can start a fresh one. Staff deny locks it
+                await this.helpers.updateRecord("Matches", match, {
+                    "Reports": []
+                });
+            } else {
+                throw "You don't have permission to start a new request on this match";
+            }
+        }
+    }
+// @ts-expect-error Needs some action refactoring before it can fully satisfy
+} satisfies Action;

--- a/server/src/actions/approve-match-reschedule.ts
+++ b/server/src/actions/approve-match-reschedule.ts
@@ -1,8 +1,9 @@
-import { ActionAuth, Match, MatchResolvableID, Report } from "../types.js";
-import { cleanID, dirtyID, getMatchRescheduling, looseDeleteMessage } from "../action-utils/action-utils.js";
+import { ActionAuth, Match, MatchResolvableID, Report, ReschedulingReportKeys } from "../types.js";
+import { cleanID, dirtyID, getMatchRescheduling, } from "../action-utils/action-utils.js";
 import { Action } from "../action-utils/action-manager-models.js";
 import { get } from "../action-utils/action-cache.js";
 import { MapObject } from "../discord/managers.js";
+import { looseDeleteRecordedMessage, looseDeleteRecordedMessages } from "../action-utils/ts-action-utils.js";
 
 export default {
     key: "approve-match-reschedule",
@@ -45,31 +46,92 @@ export default {
 
         if (reaction === "approve") {
             if (!actingTeam) throw "You don't have permission to approve this request";
-            let messageData = new MapObject(report.message_data);
-            messageData = await looseDeleteMessage(messageData, "opponent_reschedule_request");
+            if (report.approved) throw "This request has already been approved";
+            if (report.denied_by_opponent) throw "This request has already been denied";
 
-            await this.helpers.updateRecord("Reports", report, {
+            let messageData = new MapObject(report.message_data);
+
+            messageData = await looseDeleteRecordedMessage<ReschedulingReportKeys>(messageData, "reschedule_opponent_approval");
+
+            const response = await this.helpers.updateRecord("Reports", report, {
                 "Approved by opponent": true,
-                "Log": (report.log ? report.log + "\n" : "") + `${(new Date()).toLocaleString()}: ${user.airtable.name} approved reschedule request as ${actingTeam?.name}`,
+                "Log": (report.log ? report.log + "\n" : "") + [
+                    `date=${(new Date()).getTime()}`,
+                    `user=${user.airtable.id}`,
+                    `team=${actingTeam?.id}`,
+                    "text=Approved match reschedule",
+                    "key=approved_by_opponent"
+                ].join("|"),
                 "Message Data": messageData.textMap
             });
+            if ("error" in response) {
+                console.error("Airtable error", response.error);
+                throw "System error";
+            }
+            return "Match reschedule approved";
+
         } else if (reaction === "deny") {
             if (!actingTeam) throw "You don't have permission to approve this request";
-            let messageData = new MapObject(report.message_data);
-            messageData = await looseDeleteMessage(messageData, "opponent_reschedule_request");
+            if (report.approved) throw "This request has already been approved";
+            if (report.denied_by_opponent) throw "This request has already been denied";
 
-            await this.helpers.updateRecord("Reports", report, {
+            let messageData = new MapObject(report.message_data);
+            // approval messages that need to be deleted
+            messageData = await looseDeleteRecordedMessages<ReschedulingReportKeys>(messageData, ["reschedule_opponent_approval", "reschedule_staff_approval", "reschedule_staff_preapproval"]);
+
+            const response = await this.helpers.updateRecord("Reports", report, {
                 "Denied by opponent": true,
-                "Log": (report.log ? report.log + "\n" : "") + `${(new Date()).toLocaleString()}: ${user.airtable.name} denied reschedule request as ${actingTeam?.name}`,
+                "Log": (report.log ? report.log + "\n" : "") + [
+                    `date=${(new Date()).getTime()}`,
+                    `user=${user.airtable.id}`,
+                    `team=${actingTeam?.id}`,
+                    "text=Denied match reschedule",
+                    "key=denied_by_opponent"
+                ].join("|"),
                 "Message Data": messageData.textMap
             });
+            if ("error" in response) {
+                console.error("Airtable error", response.error);
+                throw "System error";
+            }
+
+            return "Match reschedule denied";
 
         } else if (reaction === "delete") {
+            // any messages from a previous approval that was denied
+
             if ((report.approved || report.denied_by_opponent) && !report.denied_by_staff) {
                 // Finished report or opponent denial can start a fresh one. Staff deny locks it
-                await this.helpers.updateRecord("Matches", match, {
-                    "Reports": []
+
+                let messageData = new MapObject(report.message_data);
+                // any messages from a previous approval that was denied
+                messageData = await looseDeleteRecordedMessages<ReschedulingReportKeys>(messageData, ["reschedule_opponent_denial", "reschedule_staff_denial", "reschedule_team_cancel", "reschedule_opponent_cancel"]);
+
+                const response = await this.helpers.updateRecord("Reports", report, {
+                    "Log": (report.log ? report.log + "\n" : "") + [
+                        `date=${(new Date()).getTime()}`,
+                        `user=${user.airtable.id}`,
+                        `team=${actingTeam?.id}`,
+                        "text=Deleted match reschedule",
+                        "key=deleted"
+                    ].join("|"),
+                    "Message Data": messageData.textMap
                 });
+                if ("error" in response) {
+                    console.error("Airtable error", response.error);
+                    throw "System error";
+                }
+                const matchClearResponse = await this.helpers.updateRecord("Matches", match, {
+                    "Reports": [],
+                    "Report History": [...(match.report_history || []), report.id].map(x => dirtyID(x))
+                });
+                if ("error" in matchClearResponse) {
+                    console.error("Airtable error", matchClearResponse.error);
+                    throw "System error";
+                }
+
+                return "Match reschedule deleted";
+
             } else {
                 throw "You don't have permission to start a new request on this match";
             }

--- a/server/src/actions/approve-score-report.ts
+++ b/server/src/actions/approve-score-report.ts
@@ -1,9 +1,9 @@
-import { ActionAuth, Match, MatchResolvableID, Report } from "../types.js";
+import { ActionAuth, Match, MatchResolvableID, Report, ScoreReportingReportKeys } from "../types.js";
 import { Action } from "../action-utils/action-manager-models.js";
 import { cleanID, dirtyID, getMatchScoreReporting } from "../action-utils/action-utils.js";
 import { get } from "../action-utils/action-cache.js";
-import client from "../discord/client.js";
 import { MapObject } from "../discord/managers.js";
+import { looseDeleteRecordedMessage } from "../action-utils/ts-action-utils.js";
 
 export default {
     key: "approve-score-report",
@@ -48,24 +48,20 @@ export default {
         if (reaction === "approve") {
             // opponent approves original's report
 
-            const messageData = new MapObject(report.message_data);
+            let messageData = new MapObject(report.message_data);
             // Remove previous captain notification
             console.log(messageData.data);
-            if (messageData.get("opponent_captain_notification_message_id") && messageData.get("opponent_captain_notification_channel_id")) {
-                try {
-                    const channel = await client.channels.fetch(messageData.get("opponent_captain_notification_channel_id"));
-                    if (channel?.isTextBased()) await channel.messages.delete(messageData.get("opponent_captain_notification_message_id"));
-                } catch (e) {
-                    console.error("Error trying to delete previous opponent captain notification message", e);
-                } finally {
-                    messageData.push("opponent_captain_notification_message_id", null);
-                    messageData.push("opponent_captain_notification_channel_id", null);
-                }
-            }
 
+            messageData = await looseDeleteRecordedMessage<ScoreReportingReportKeys>(messageData, "report_opponent_notification");
             await this.helpers.updateRecord("Reports", report, {
                 "Approved by opponent": true,
-                "Log": (report.log ? report.log + "\n" : "") + `${(new Date()).toLocaleString()}: ${user.airtable.name} approved score report as ${actingTeam?.name}`,
+                "Log": (report.log ? report.log + "\n" : "") + [
+                    `date=${(new Date()).getTime()}`,
+                    `user=${user.airtable.id}`,
+                    `team=${actingTeam?.id}`,
+                    "text=Approved score report",
+                    "key=approved_by_opponent"
+                ].join("|"),
                 "Message Data": messageData.textMap
             });
 
@@ -73,21 +69,11 @@ export default {
         } else if (reaction === "counter-approve") {
             // original approves opponent's counter report
 
-            const messageData = new MapObject(report.message_data);
+            let messageData = new MapObject(report.message_data);
             // Remove previous captain notification
             console.log(messageData.data);
-            if (messageData.get("original_captain_notification_message_id") && messageData.get("original_captain_notification_channel_id")) {
-                try {
-                    const channel = await client.channels.fetch(messageData.get("original_captain_notification_channel_id"));
-                    if (channel?.isTextBased()) await channel.messages.delete(messageData.get("original_captain_notification_message_id"));
-                } catch (e) {
-                    console.error("Error trying to delete previous opponent captain notification message", e);
-                } finally {
-                    messageData.push("original_captain_notification_message_id", null);
-                    messageData.push("original_captain_notification_channel_id", null);
-                }
-            }
 
+            messageData = await looseDeleteRecordedMessage<ScoreReportingReportKeys>(messageData, "report_opponent_notification");
 
             await this.helpers.updateRecord("Reports", report, {
                 "Approved by opponent": true,
@@ -95,7 +81,14 @@ export default {
                 "Countered by opponent": false,
                 "Data": report.countered_data,
                 "Countered Data": "",
-                "Log": (report.log ? report.log + "\n" : "") + `${(new Date()).toLocaleString()}: ${user.airtable.name} approved counter report as ${actingTeam?.name}`
+                "Log": (report.log ? report.log + "\n" : "") + [
+                    `date=${(new Date()).getTime()}`,
+                    `user=${user.airtable.id}`,
+                    `team=${actingTeam?.id}`,
+                    "text=Approved counter report",
+                    "key=approved_counter_report"
+                ].join("|"),
+                // `${(new Date()).toLocaleString()}: ${user.airtable.name} approved counter report as ${actingTeam?.name}`
             });
         }
     }

--- a/server/src/actions/approve-score-report.ts
+++ b/server/src/actions/approve-score-report.ts
@@ -48,7 +48,6 @@ export default {
         if (reaction === "approve") {
             // opponent approves original's report
 
-
             const messageData = new MapObject(report.message_data);
             // Remove previous captain notification
             console.log(messageData.data);

--- a/server/src/actions/create-event-discord-items.js
+++ b/server/src/actions/create-event-discord-items.js
@@ -41,7 +41,7 @@ export default {
      * @param {boolean?} settings.roles.pingable
      * @param {boolean?} settings.roles.hoist
      * @param {string?} settings.teamEmoji.format
-     * @param {UserData} user
+     * @param {ActionAuth["user"]} user
      * @returns {Promise<void>}
      */
     async handler({ eventID, guildID, actions, settings }, { user }) {

--- a/server/src/actions/create-live-guest.js
+++ b/server/src/actions/create-live-guest.js
@@ -1,11 +1,12 @@
 import { deAirtable } from "../action-utils/action-utils.js";
+
 export default {
     key: "create-live-guest",
     requiredParams: [],
     auth: ["user"],
     /***
      * @param {Object?} params
-     * @param {UserData} user
+     * @param {ActionAuth["user"]} user
      * @returns {Promise<{}>}
      */
     async handler(params, { user }) {

--- a/server/src/actions/manage-prediction.js
+++ b/server/src/actions/manage-prediction.js
@@ -46,7 +46,7 @@ export default {
      * @param {"create"|"lock"|"resolve"|"cancel"} predictionAction
      * @param {"match"|"map"} predictionType
      * @param {number?} autoLockAfter
-     * @param {ClientData} client
+     * @param {Client} client
      * @returns {Promise<void>}
      */
     // eslint-disable-next-line no-empty-pattern

--- a/server/src/actions/match-discord-slmngg-player.js
+++ b/server/src/actions/match-discord-slmngg-player.js
@@ -7,7 +7,7 @@ export default {
     auth: ["user"],
     /***
      * @param {import("discord.js").User} discordData
-     * @param {UserData} user
+     * @param {ActionAuth["user"]} user
      * @returns {Promise<UserData[]>}
      */
     async handler({ discordData }, { user }) {

--- a/server/src/actions/send-match-discord-message.js
+++ b/server/src/actions/send-match-discord-message.js
@@ -7,8 +7,9 @@ export default {
     auth: ["client", "user"],
     /***
      * @param {Object?} params
-     * @param {ClientData} client
-     * @param {CacheGetFunction} get
+     * @param {ActionAuth["user"]} user
+     * @param {ActionAuth["client"]} client
+     * @param {ActionAuth["isAutomation"]} isAutomation
      * @returns {Promise<string>}
      */
     // eslint-disable-next-line no-empty-pattern

--- a/server/src/actions/set-active-broadcast.ts
+++ b/server/src/actions/set-active-broadcast.ts
@@ -9,8 +9,7 @@ export default {
     /***
      * @param {DirtyAirtableID} broadcastID
      * @param {DirtyAirtableID} clientID
-     * @param {UserData} user
-     * @param {ClientData} client
+     * @param {ActionAuth["client"]} client
      * @returns {Promise<void>}
      */
     async handler(

--- a/server/src/actions/set-event-guild.js
+++ b/server/src/actions/set-event-guild.js
@@ -8,7 +8,7 @@ export default {
     /***
      * @param {Snowflake} guildID
      * @param {AnyAirtableID} eventID
-     * @param {UserData} user
+     * @param {ActionAuth["user"]} user
      * @returns {Promise<void>}
      */
     async handler({ eventID, guildID }, { user }) {

--- a/server/src/actions/set-marker.js
+++ b/server/src/actions/set-marker.js
@@ -7,8 +7,7 @@ export default {
     optionalParams: ["text"],
     /***
      * @param {Object?} params
-     * @param {ClientData} client
-     * @param {CacheGetFunction} get
+     * @param {ActionAuth["client"]} client
      * @returns {Promise<string>}
      */
     // eslint-disable-next-line no-empty-pattern

--- a/server/src/actions/set-match-overlays.js
+++ b/server/src/actions/set-match-overlays.js
@@ -4,7 +4,7 @@ export default {
     requiredParams: ["match", "overlayType", "state"],
     /***
      * @param {Object?} params
-     * @param {ClientData} client
+     * @param {ActionAuth["user"]} user
      * @returns {Promise<void>}
      */
     // eslint-disable-next-line no-empty-pattern

--- a/server/src/actions/set-observer-setting.js
+++ b/server/src/actions/set-observer-setting.js
@@ -4,7 +4,7 @@ export default {
     auth: ["client"],
     /***
      * @param {Object?} params
-     * @param {ClientData} client
+     * @param {ActionAuth["client"]} client
      * @returns {Promise<void>}
      */
     // eslint-disable-next-line no-empty-pattern

--- a/server/src/actions/set-player-cams.js
+++ b/server/src/actions/set-player-cams.js
@@ -6,7 +6,7 @@ export default {
     requiredParams: ["cams"],
     /***
      * @param {AnyAirtableID[][]} cams
-     * @param {ClientData} client
+     * @param {ActionAuth["client"]} client
      * @returns {Promise<void>}
      */
     // eslint-disable-next-line no-empty-pattern

--- a/server/src/actions/set-player-relationships.js
+++ b/server/src/actions/set-player-relationships.js
@@ -30,7 +30,7 @@ export default {
      * @typedef {"Team 1" | "Team 2" | "None"} Cams
      * @typedef {{ clientID: AnyAirtableID, cams: Cams[] }[]} CamsData
      * @param {Object?} params
-     * @param {ClientData} client
+     * @param {ActionAuth["user"]} user
      * @param {CamsData} clientCams
      * @returns {Promise<void>}
      */

--- a/server/src/actions/set-player-remote-feed.js
+++ b/server/src/actions/set-player-remote-feed.js
@@ -5,6 +5,7 @@ export default {
     /***
      * @param { ? } player
      * @param { string } feed
+     * @param {boolean} isAutomation
      */
     async handler({ player, feed }, { isAutomation }) {
         if (!isAutomation) throw "This action can only be run internally.";

--- a/server/src/actions/set-player-signup-data.js
+++ b/server/src/actions/set-player-signup-data.js
@@ -18,7 +18,7 @@ export default {
      * @param {object[]} allPlayerData
      * @param {boolean} useSignupData
      * @param {boolean} createPlayers
-     * @param {UserData} user
+     * @param {ActionAuth["user"]} user
      * @returns {Promise<*[]>}
      */
     async handler({ eventID, playerData: allPlayerData, useSignupData, createPlayers }, { user }) {

--- a/server/src/actions/set-player-signup-data.js
+++ b/server/src/actions/set-player-signup-data.js
@@ -118,6 +118,8 @@ export default {
                 if (playerData?.discord_tag) airtablePlayerData["Discord Tag"] = playerData.discord_tag.replace("@", "").trim();
                 // if (playerData?.discord_id) airtablePlayerData["Discord ID"] = playerData.discord_id;
                 if (playerData?.battletag) airtablePlayerData["Battletag"] = playerData.battletag;
+                if (playerData?.pronouns) airtablePlayerData["Pronouns"] = playerData.pronouns.toLowerCase().trim();
+                if (playerData?.pronunciation) airtablePlayerData["Pronunciation"] = playerData.pronunciation;
 
                 if (playerData.team_id) airtablePlayerData["Member Of"] = [dirtyID(playerData.team_id)];
 
@@ -159,7 +161,8 @@ export default {
                         data: playerData?.eligible_roles?.split(", ")?.filter(Boolean),
                     },
                     {
-                        signupDataKey: "role",
+                        playerDataKey: "role",
+                        signupDataKey: "main_role",
                         airtableKey: "Main Role",
                     },
                     {
@@ -182,9 +185,8 @@ export default {
                         signupDataKey: "info_for_captains",
                         airtableKey: "Info For Captains",
                     }
-                ].forEach(({ signupDataKey, airtableKey, data }) => {
-                    data = data || playerData?.[signupDataKey];
-                    // console.log(airtableKey, data, signupRecord?.[signupDataKey]);
+                ].forEach(({ signupDataKey, playerDataKey, airtableKey, data }) => {
+                    data = data || playerData?.[playerDataKey || signupDataKey];
                     // if (!data) return;
 
                     if (signupRecord) {
@@ -302,11 +304,16 @@ export default {
                     { signupDataKey: "discord_tag", airtableKey: "Discord Tag", },
                     // { signupDataKey: "discord_id", airtableKey: "Discord ID", },
                     { signupDataKey: "battletag", airtableKey: "Battletag", },
+                    { signupDataKey: "pronouns", airtableKey: "Pronouns", validation: (str) => str?.toLowerCase()?.trim() },
+                    { signupDataKey: "pronunciation", airtableKey: "Pronunciation", },
                 ];
 
-                alwaysAllowedPlayerUpdate.forEach(({ signupDataKey, airtableKey, data }) => {
+                alwaysAllowedPlayerUpdate.forEach(({ signupDataKey, airtableKey, data, validation }) => {
                     data = data || playerData?.[signupDataKey];
 
+                    if (validation) {
+                        data = validation(data);
+                    }
                     // console.log(airtableKey, data, playerData?.[signupDataKey]);
 
                     if (player[signupDataKey] === data) return;
@@ -317,7 +324,6 @@ export default {
 
                 if (Object.keys(playerUpdateData)?.length) {
                     console.log(playerUpdateData);
-                    console.log(player);
                     await this.helpers.updateRecord("Players", player, playerUpdateData);
                 }
             }

--- a/server/src/actions/set-title.js
+++ b/server/src/actions/set-title.js
@@ -6,8 +6,8 @@ export default {
     auth: ["client"],
     /***
      * @param {Object?} params
-     * @param {ClientData} client
-     * @param {CacheGetFunction} get
+     * @param {ActionAuth["client"]} client
+     * @param {ActionAuth["isAutomation"]} isAutomation
      * @returns {Promise<string>}
      */
     // eslint-disable-next-line no-empty-pattern

--- a/server/src/actions/staff-approve-match-reschedule.ts
+++ b/server/src/actions/staff-approve-match-reschedule.ts
@@ -1,0 +1,83 @@
+import { ActionAuth, Match, MatchResolvableID, Report } from "../types.js";
+import { Action } from "../action-utils/action-manager-models.js";
+import { getMatchRescheduling, looseDeleteMessage } from "../action-utils/action-utils.js";
+import { get } from "../action-utils/action-cache.js";
+import { isEventStaffOrHasRole } from "../action-utils/action-permissions.js";
+import { MapObject } from "../discord/managers.js";
+
+export default {
+    key: "staff-approve-match-reschedule",
+    requiredParams: ["matchID", "reaction"],
+    auth: ["user"],
+    async handler(
+        { matchID, reaction }: { matchID: MatchResolvableID, reaction: "approve" | "pre-approve" | "force-approve" | "deny" | "delete" },
+        { user }: ActionAuth
+    ) {
+        const { match, report } : { match: Match, report: Report | undefined } = await getMatchRescheduling(matchID);
+        if (!report) {
+            throw "There is no match rescheduling request on this match";
+        }
+
+        if (!match?.event?.[0]) throw "Event couldn't be loaded for this match";
+        const event = await get(match.event[0]);
+        if (!event?.id) throw "Event couldn't be loaded for this match";
+
+        if (!(await isEventStaffOrHasRole(user, event, null, ["Can edit any match", "Can edit any event", "Full broadcast permissions"]))) {
+            throw "You don't have permission to edit this match, including match rescheduling.";
+        }
+
+        let messageData = new MapObject(report.message_data);
+
+        // Remove previous notifications
+        messageData = await looseDeleteMessage(messageData, "staff_reschedule_notification");
+
+        if (reaction === "pre-approve") {
+            await this.helpers.updateRecord("Reports", report, {
+                "Approved by staff": true,
+                "Log": (report.log ? report.log + "\n" : "") + `${(new Date()).toLocaleString()}: ${user.airtable.name} pre-approved match reschedule request as staff`,
+                "Message Data": messageData.textMap
+            }, "actions/staff-approve-match-reschedule");
+        } else if (reaction === "approve") {
+            await this.helpers.updateRecord("Reports", report, {
+                "Approved by staff": true,
+                "Log": (report.log ? report.log + "\n" : "") + `${(new Date()).toLocaleString()}: ${user.airtable.name} approved match reschedule request as staff`,
+                "Message Data": messageData.textMap
+            }, "actions/staff-approve-match-reschedule");
+        } else if (reaction === "force-approve") {
+            messageData = await looseDeleteMessage(messageData, "opponent_captain_notification");
+
+            await this.helpers.updateRecord("Reports", report, {
+                "Approved by staff": true,
+                "Force approved": true,
+                "Log": (report.log ? report.log + "\n" : "") + `${(new Date()).toLocaleString()}: ${user.airtable.name} force-approved match reschedule as staff`,
+                "Message Data": messageData.textMap
+            }, "actions/staff-approve-match-reschedule");
+        } else if (reaction === "deny") {
+            messageData = await looseDeleteMessage(messageData, "opponent_captain_notification");
+
+            await this.helpers.updateRecord("Reports", report, {
+                "Denied by staff": true,
+                "Log": (report.log ? report.log + "\n" : "") + `${(new Date()).toLocaleString()}: ${user.airtable.name} denied match reschedule as staff`,
+                "Message Data": messageData.textMap
+            }, "actions/staff-approve-match-reschedule");
+        } else if (reaction === "delete") {
+            messageData = await looseDeleteMessage(messageData, "opponent_captain_notification");
+
+            await this.helpers.updateRecord("Reports", report, {
+                "Log": (report.log ? report.log + "\n" : "") + `${(new Date()).toLocaleString()}: ${user.airtable.name} deleted match reschedule as staff`,
+                "Message Data": messageData.textMap
+            }, "actions/staff-approve-match-reschedule");
+            await this.helpers.updateRecord("Matches", match, {
+                "Reports": []
+            }, "actions/staff-approve-match-reschedule");
+        } else {
+            throw {
+                errorCode: 501,
+                errorMessage: "Unknown method for staff approvals"
+            };
+        }
+
+
+    }
+// @ts-expect-error Needs some action refactoring before it can fully satisfy
+} satisfies Action;

--- a/server/src/actions/staff-approve-score-report.ts
+++ b/server/src/actions/staff-approve-score-report.ts
@@ -1,10 +1,11 @@
-import { ActionAuth, EventSettings, Match, MatchResolvableID, Report } from "../types.js";
+import { ActionAuth, EventSettings, Match, MatchResolvableID, Report, ScoreReportingReportKeys } from "../types.js";
 import { Action } from "../action-utils/action-manager-models.js";
-import { cleanID, getMatchScoreReporting, looseDeleteMessage } from "../action-utils/action-utils.js";
+import { cleanID, dirtyID, getMatchScoreReporting } from "../action-utils/action-utils.js";
 import { get } from "../action-utils/action-cache.js";
 import { isEventStaffOrHasRole } from "../action-utils/action-permissions.js";
 import { MapObject } from "../discord/managers.js";
 import client from "../discord/client.js";
+import { looseDeleteRecordedMessage, looseDeleteRecordedMessages } from "../action-utils/ts-action-utils.js";
 
 export default {
     key: "staff-approve-score-report",
@@ -31,26 +32,44 @@ export default {
 
         console.log(messageData.data);
         // Remove previous staff notifications
-        messageData = await looseDeleteMessage(messageData, "staff_notification");
+        messageData = await looseDeleteRecordedMessage<ScoreReportingReportKeys>(messageData, "report_staff_notification");
 
         if (reaction === "pre-approve") {
             await this.helpers.updateRecord("Reports", report, {
                 "Approved by staff": true,
-                "Log": (report.log ? report.log + "\n" : "") + `${(new Date()).toLocaleString()}: ${user.airtable.name} pre-approved score report as staff`,
+                "Log": (report.log ? report.log + "\n" : "") + [
+                    `date=${(new Date()).getTime()}`,
+                    `user=${user.airtable.id}`,
+                    "staff=true",
+                    "text=Pre-approved score report",
+                    "key=staff_preapproved"
+                ].join("|"),
                 "Message Data": messageData.textMap
             });
         } else if (reaction === "approve") {
             await this.helpers.updateRecord("Reports", report, {
                 "Approved by staff": true,
-                "Log": (report.log ? report.log + "\n" : "") + `${(new Date()).toLocaleString()}: ${user.airtable.name} approved score report as staff`,
+                "Log": (report.log ? report.log + "\n" : "") + [
+                    `date=${(new Date()).getTime()}`,
+                    `user=${user.airtable.id}`,
+                    "staff=true",
+                    "text=Approved score report",
+                    "key=staff_approved"
+                ].join("|"),
                 "Message Data": messageData.textMap
             });
         } else if (reaction === "force-approve") {
-            messageData = await looseDeleteMessage(messageData, "opponent_captain_notification");
+            messageData = await looseDeleteRecordedMessage<ScoreReportingReportKeys>(messageData, "report_opponent_notification");
             await this.helpers.updateRecord("Reports", report, {
                 "Approved by staff": true,
                 "Force approved": true,
-                "Log": (report.log ? report.log + "\n" : "") + `${(new Date()).toLocaleString()}: ${user.airtable.name} force-approved score report as staff`,
+                "Log": (report.log ? report.log + "\n" : "") + [
+                    `date=${(new Date()).getTime()}`,
+                    `user=${user.airtable.id}`,
+                    "staff=true",
+                    "text=Force-approved score report",
+                    "key=staff_force_approved"
+                ].join("|"),
                 "Message Data": messageData.textMap
             });
         } else if (reaction === "force-counter-approve") {
@@ -62,16 +81,21 @@ export default {
                 "Data": report.countered_data,
                 "Countered Data": "",
 
-                "Log": (report.log ? report.log + "\n" : "") + `${(new Date()).toLocaleString()}: ${user.airtable.name} force-approved counter score report as staff`,
+                "Log": (report.log ? report.log + "\n" : "")  + [
+                    `date=${(new Date()).getTime()}`,
+                    `user=${user.airtable.id}`,
+                    "staff=true",
+                    "text=Force-approved counter report",
+                    "key=staff_force_approved_counter"
+                ].join("|"),
                 "Message Data": messageData.textMap
             });
         } else if (reaction === "delete") {
-            messageData = await looseDeleteMessage(messageData, "opponent_captain_notification");
-            messageData = await looseDeleteMessage(messageData, "staff_notification");
-            messageData = await looseDeleteMessage(messageData, "staff_confirmation");
+            messageData = await looseDeleteRecordedMessages<ScoreReportingReportKeys>(messageData, ["report_opponent_notification", "report_staff_notification", "report_completed_staff", "report_completed_public"]);
 
             await this.helpers.updateRecord("Matches", match, {
-                "Reports": []
+                "Reports": [],
+                "Report History": [...(match.report_history || []), report.id].map(x => dirtyID(x))
             });
 
             const eventSettings = JSON.parse(event.blocks || "") as EventSettings;

--- a/server/src/actions/staff-approve-score-report.ts
+++ b/server/src/actions/staff-approve-score-report.ts
@@ -107,7 +107,7 @@ export default {
 
             if (client && eventSettings?.logging?.staffScoreReport) {
                 const channel = await client.channels.fetch(eventSettings.logging.staffScoreReport);
-                if (channel?.isTextBased()) {
+                if (channel?.isSendable()) {
                     try {
                         await channel.send(`🗑️ **Denied & deleted**: Score report removed by ${user.airtable.name}.\n${matchLink}`);
                     } catch (e) {

--- a/server/src/actions/start-commercial.js
+++ b/server/src/actions/start-commercial.js
@@ -6,8 +6,8 @@ export default {
     requiredParams: ["commercialDuration"],
     /***
      * @param {30 | 60 | 90 | 120 | 150 | 180} commercialDuration
-     * @param {UserData} user
-     * @param {ClientData} client
+     * @param {ActionAuth["user"]} user
+     * @param {ActionAuth["client"]} client
      * @returns {Promise<void>}
      */
     // eslint-disable-next-line no-empty-pattern

--- a/server/src/actions/submit-match-reschedule.ts
+++ b/server/src/actions/submit-match-reschedule.ts
@@ -1,0 +1,56 @@
+import { ActionAuth, Match, MatchResolvableID, Report } from "../types.js";
+import { deAirtableRecord, dirtyID, getMatchRescheduling } from "../action-utils/action-utils.js";
+import { get } from "../action-utils/action-cache.js";
+import { Action } from "../action-utils/action-manager-models.js";
+
+export default {
+    key: "submit-match-reschedule",
+    requiredParams: ["matchID", "startTime"],
+    auth: ["user"],
+    async handler(
+        {matchID, startTime}: {
+            matchID: MatchResolvableID,
+            startTime: string
+        },
+        {user}: ActionAuth
+    ) {
+        const { match, report: request } : { match: Match, report: Report | undefined } = await getMatchRescheduling(matchID, { excludeCompleted: true });
+        if (request) {
+            throw "A reschedule request is already active on this match.";
+        }
+
+        const teams = await Promise.all((match.teams || []).map(t => get(t)));
+        const actingTeam = teams.find(team => [
+            ...(team.players || []),
+            ...(team.captains || []),
+            ...(team.staff || []),
+            ...(team.owners || []),
+        ].includes(dirtyID(user.airtable.id)));
+
+        if (!actingTeam) throw "You don't have permission to report the score of this match";
+
+        const response = await this.helpers.createRecord("Reports", {
+            "Type": "Rescheduling",
+            "Player": [dirtyID(user.airtable.id)],
+            "Team": [dirtyID(actingTeam.id)],
+            "Match": [dirtyID(match.id)],
+            "Data": JSON.stringify({
+                start: startTime
+            }),
+            "Log": `${(new Date()).toLocaleString()}: ${user.airtable.name} requested reschedule as ${actingTeam?.name}`
+        });
+        if ("error" in response) {
+            throw `Airtable error: ${response.errorMessage}`;
+        }
+        if (response?.[0]?.id) {
+            await this.helpers.updateRecord("Matches", match, {
+                "Reports": [...(match.reports || []), response?.[0].id]
+            });
+            await this.helpers.updateRecord("Reports", deAirtableRecord(response[0]), {
+                "Approved by team": true
+            });
+            return response?.[0].id;
+        }
+    }
+// @ts-expect-error Needs some action refactoring before it can fully satisfy
+} satisfies Action;

--- a/server/src/actions/submit-match-reschedule.ts
+++ b/server/src/actions/submit-match-reschedule.ts
@@ -29,6 +29,14 @@ export default {
 
         if (!actingTeam) throw "You don't have permission to report the score of this match";
 
+        if (match.start) {
+            const startTimeDate = new Date(startTime);
+            const matchTimeDate = new Date(match.start);
+            if (startTimeDate.getTime() === matchTimeDate.getTime()) {
+                throw "The match is already scheduled for this time";
+            }
+        }
+
         const response = await this.helpers.createRecord("Reports", {
             "Type": "Rescheduling",
             "Player": [dirtyID(user.airtable.id)],
@@ -37,7 +45,13 @@ export default {
             "Data": JSON.stringify({
                 start: startTime
             }),
-            "Log": `${(new Date()).toLocaleString()}: ${user.airtable.name} requested reschedule as ${actingTeam?.name}`
+            "Log": [
+                `date=${(new Date()).getTime()}`,
+                `user=${user.airtable.id}`,
+                `team=${actingTeam?.id}`,
+                `text=Requested ${match.start ? "schedule" : "reschedule"}`,
+                "key=submitted_request"
+            ].join("|")
         });
         if ("error" in response) {
             throw `Airtable error: ${response.errorMessage}`;

--- a/server/src/actions/submit-score-report.ts
+++ b/server/src/actions/submit-score-report.ts
@@ -42,7 +42,13 @@ export default {
                 "Team": [dirtyID(actingTeam.id)],
                 "Match": [dirtyID(match.id)],
                 "Data": JSON.stringify(reportData),
-                "Log": `${(new Date()).toLocaleString()}: ${user.airtable.name} reported score as ${actingTeam?.name}`
+                "Log": [
+                    `date=${(new Date()).getTime()}`,
+                    `user=${user.airtable.id}`,
+                    `team=${actingTeam?.id}`,
+                    "text=Reported score",
+                    "key=submitted_score_report"
+                ].join("|"),
             });
 
             console.log(response);
@@ -79,7 +85,13 @@ export default {
             if (!actingTeam) throw "You don't have permission to counter the score report of this match";
 
             const response = await this.helpers.updateRecord("Reports", report, {
-                "Log": report.log + "\n" + `${(new Date()).toLocaleString()}: ${user.airtable.name} countered score report as ${actingTeam?.name}`,
+                "Log": report.log + "\n" + [
+                    `date=${(new Date()).getTime()}`,
+                    `user=${user.airtable.id}`,
+                    `team=${actingTeam?.id}`,
+                    "text=Coutered score report",
+                    "key=countered_score_report"
+                ].join("|"),
                 "Countered Data": JSON.stringify(reportData),
                 "Countered by opponent": true
             });

--- a/server/src/actions/toggle-flip-teams.js
+++ b/server/src/actions/toggle-flip-teams.js
@@ -3,7 +3,7 @@ export default {
     auth: ["client"],
     /***
      * @param {Object?} params
-     * @param {ClientData} client
+     * @param {ActionAuth["client"]} client
      * @returns {Promise<void>}
      */
     // eslint-disable-next-line no-empty-pattern

--- a/server/src/actions/update-break-automation.js
+++ b/server/src/actions/update-break-automation.js
@@ -6,7 +6,7 @@ export default {
     requiredParams: ["options"],
     /***
      * @param {string[]} options
-     * @param {ClientData} client
+     * @param {ActionAuth["client"]} client
      * @returns {Promise<void>}
      */
     // eslint-disable-next-line no-empty-pattern

--- a/server/src/actions/update-break-display.js
+++ b/server/src/actions/update-break-display.js
@@ -6,7 +6,7 @@ export default {
     requiredParams: ["option"],
     /***
      * @param {string} option
-     * @param {ClientData} client
+     * @param {ActionAuth["client"]} client
      * @returns {Promise<void>}
      */
     // eslint-disable-next-line no-empty-pattern

--- a/server/src/actions/update-broadcast.js
+++ b/server/src/actions/update-broadcast.js
@@ -6,7 +6,7 @@ export default {
     optionalParams: ["match", "advertise", "playerCams", "mapAttack", "title", "manualGuests", "deskDisplayMode", "deskDisplayText", "showLiveMatch", "countdownEnd", "highlightTeamID", "highlightHeroID", "highlightPlayerID", "highlightMediaID"],
     /***
      * @param {AnyAirtableID} match
-     * @param {ClientData} client
+     * @param {ActionAuth["client"]} client
      * @returns {Promise<void>}
      */
     // eslint-disable-next-line no-empty-pattern

--- a/server/src/actions/update-gfx-index.js
+++ b/server/src/actions/update-gfx-index.js
@@ -7,7 +7,7 @@ export default {
     /***
      * @param {AnyAirtableID} gfxID
      * @param {number} index
-     * @param {ClientData} client
+     * @param {ActionAuth["client"]} client
      * @returns {Promise<void>}
      */
     // eslint-disable-next-line no-empty-pattern

--- a/server/src/actions/update-map-data.js
+++ b/server/src/actions/update-map-data.js
@@ -17,7 +17,8 @@ export default {
      * @param {number?} mapData.score_2
      * @param {boolean?} mapData.draw
      *
-     * @param {UserData} user
+     * @param {ActionAuth["user"]} user
+     * @param {ActionAuth["isAutomation"]} isAutomation
      * @returns {Promise<void>}
      */
     async handler({ matchID, mapData }, { user, isAutomation }) {

--- a/server/src/actions/update-match-data.js
+++ b/server/src/actions/update-match-data.js
@@ -5,7 +5,8 @@ export default {
     /***
      * @param {AnyAirtableID} matchID
      * @param {object?} updatedData
-     * @param {UserData} user
+     * @param {ActionAuth["user"]} user
+     * @param {ActionAuth["isAutomation"]} isAutomation
      * @returns {Promise<void>}
      */
     async handler({ matchID, updatedData }, { user, isAutomation }) {

--- a/server/src/actions/update-player-discord-id.js
+++ b/server/src/actions/update-player-discord-id.js
@@ -12,7 +12,7 @@ export default {
     /***
      * @param {import("discord.js").User} discordData
      * @param {string} slmnggId
-     * @param {UserData} user
+     * @param {ActionAuth["user"]} user
      * @returns {Promise<string>}
      */
     async handler({ discordData, slmnggId }, { user }) {

--- a/server/src/actions/update-profile-data.js
+++ b/server/src/actions/update-profile-data.js
@@ -7,7 +7,7 @@ export default {
     auth: ["user"],
     /***
      * @param {object} profileData
-     * @param {UserData} user
+     * @param {ActionAuth["user"]} user
      * @returns {Promise<void>}
      */
     async handler({ profileData }, { user }) {

--- a/server/src/automation/on-score-report-update.ts
+++ b/server/src/automation/on-score-report-update.ts
@@ -1,13 +1,27 @@
-import { AnyAirtableID, EventSettings, Report } from "../types.js";
+import {
+    AnyAirtableID,
+    EventSettings,
+    Report,
+    ReschedulingReportKeys,
+    ScoreReportingReportKeys,
+    Theme
+} from "../types.js";
 import { get } from "../action-utils/action-cache.js";
 import * as Cache from "../cache.js";
 import { getInternalManager } from "../action-utils/action-manager.js";
-import { cleanID, hammerTime, looseDeleteMessage, sendMessage, updateRecord } from "../action-utils/action-utils.js";
+import { cleanID, hammerTime, updateRecord } from "../action-utils/action-utils.js";
 import client from "../discord/client.js";
 import { MapObject } from "../discord/managers.js";
-import { generateMatchReportText } from "../action-utils/ts-action-utils.js";
+import {
+    generateMatchReportText,
+    looseDeleteRecordedMessage,
+    looseDeleteRecordedMessages,
+    sendRecordedMessage
+} from "../action-utils/ts-action-utils.js";
+import { ButtonBuilder, ButtonStyle } from "discord.js";
 
 const processing = new Set<AnyAirtableID>();
+const dataServer = process.env.NODE_ENV === "development" ? "http://localhost:8901" : "https://data.slmn.gg";
 
 export default {
     async handler({ id, newData: report, oldData }: { id: AnyAirtableID, newData: Report, oldData: Report }) {
@@ -30,6 +44,13 @@ export default {
             const event = await get(match?.event?.[0]);
             if (!event?.id || !event?.blocks) return;
 
+            const defaultColor = "#4468a8";
+            let eventTheme: Theme | null = null;
+            if (event?.theme?.length) {
+                eventTheme = await get(event.theme[0]);
+            }
+            const eventColor = parseInt((eventTheme?.color_theme_on_dark || eventTheme?.color_theme || defaultColor).slice(1), 16);
+
             const opponentIDs = (match.teams || []).filter(id => cleanID(id) !== cleanID(report.team?.[0]));
             const opponents = await Promise.all(opponentIDs.map(id => get(id)));
             const submittingTeam = report.team?.[0] ? await get(report.team?.[0]) : null;
@@ -50,7 +71,9 @@ export default {
                     report.force_approved || (
                         (report.approved_by_team &&
                             (eventSettings.reporting.score.opponentApprove ? report.approved_by_opponent : true) &&
-                            (eventSettings.reporting.score.staffApprove ? report.approved_by_staff : true))
+                            (eventSettings.reporting.score.staffApprove ? report.approved_by_staff : true)) &&
+                        !report.denied_by_staff &&
+                        !report.denied_by_opponent
                     );
 
                 if (reportApproved) {
@@ -59,7 +82,7 @@ export default {
                     const manager = getInternalManager();
                     if (!manager) return console.error("No internal manager can run automation action");
                     try {
-                        const { matchData, mapData } = JSON.parse(report.data);
+                        const {matchData, mapData} = JSON.parse(report.data);
                         console.log({
                             matchData,
                             mapData
@@ -79,22 +102,19 @@ export default {
                         // Delete record here (not implemented?)
                         console.log("Can now delete the score report");
 
-                        messageData = await looseDeleteMessage(messageData, "staff_notification");
+                        messageData = await looseDeleteRecordedMessage<ScoreReportingReportKeys>(messageData, "report_staff_notification");
 
-                        if (client &&
-                            opponents.length &&
-                            eventSettings?.logging?.staffCompletedScoreReport
-                        ) {
-                            messageData = await sendMessage({
-                                key: "staff_confirmation",
+                        if (client && eventSettings?.logging?.staffCompletedScoreReport) {
+                            messageData = await sendRecordedMessage<ScoreReportingReportKeys>({
+                                key: "report_completed_staff",
                                 mapObject: messageData,
                                 channelID: eventSettings.logging.staffCompletedScoreReport,
                                 content: `🎉 Score report approved\n${report.log}\n${matchLink}/score-reporting`
                             });
                         }
                         if (client && eventSettings?.logging?.postMatchReports) {
-                            messageData = await sendMessage({
-                                key: "score_report",
+                            messageData = await sendRecordedMessage<ScoreReportingReportKeys>({
+                                key: "report_completed_public",
                                 mapObject: messageData,
                                 channelID: eventSettings.logging.postMatchReports,
                                 content: await generateMatchReportText(await get(match.id))
@@ -104,7 +124,7 @@ export default {
                         await updateRecord(Cache, "Reports", report, {
                             "Approved": true,
                             "Message Data": messageData.textMap
-                        });
+                        }, "automation/on-score-report-update");
 
                     } catch (e) {
                         console.error("Action error - not continuing");
@@ -123,15 +143,15 @@ export default {
                             eventSettings?.reporting?.score?.staffApprove &&
                             !report.approved_by_staff
                         ) {
-                            messageData = await sendMessage({
-                                key: "staff_notification",
+                            messageData = await sendRecordedMessage<ScoreReportingReportKeys>({
+                                key: "report_staff_notification",
                                 mapObject: messageData,
                                 channelID: eventSettings.logging.staffScoreReport,
                                 content: `📣 A score report from ${submittingTeam ? submittingTeam.name : "a team"} has been approved by their opponent and is ready for staff approval\n${matchLink}/score-reporting`,
                                 success: async (mapObject : MapObject) => {
                                     await updateRecord(Cache, "Reports", report, {
                                         "Message Data": mapObject.textMap
-                                    });
+                                    }, "automation/on-score-report-update");
                                 }
                             });
                         }
@@ -152,34 +172,34 @@ export default {
                                 const discordControl = new MapObject(opponent?.discord_control);
                                 return discordControl.get("role_id") ? `<@&${discordControl.get("role_id")}>` : opponent.name;
                             });
-                            messageData = await sendMessage({
-                                key: "opponent_captain_notification",
+                            messageData = await sendRecordedMessage<ScoreReportingReportKeys>({
+                                key: "report_opponent_notification",
                                 mapObject: messageData,
                                 channelID: eventSettings.logging.captainNotifications,
                                 content: `📣 ${opponentPings.join(" ")}\nA score report from ${submittingTeam ? submittingTeam.name : "your opponent"} is ready for approval\n${matchLink}/score-reporting`,
                                 success: async (mapObject : MapObject) => {
                                     await updateRecord(Cache, "Reports", report, {
                                         "Message Data": mapObject.textMap
-                                    });
+                                    }, "automation/on-score-report-update");
                                 }
                             });
 
                             // we can also go straight to staff approving if necessary
                         } else if (client &&
                             (!eventSettings?.reporting?.score?.opponentApprove || report.approved_by_opponent) && // passed opponent approval
-                            eventSettings?.logging?.staffScoreReport &&
+                            eventSettings?.logging?.staffApprovalNotifications &&
                             eventSettings?.reporting?.score?.staffApprove &&
                             !report.approved_by_staff
                         ) {
-                            messageData = await sendMessage({
-                                key: "staff_notification",
+                            messageData = await sendRecordedMessage<ScoreReportingReportKeys>({
+                                key: "report_staff_notification",
                                 mapObject: messageData,
-                                channelID: eventSettings.logging.staffScoreReport,
+                                channelID: eventSettings.logging.staffApprovalNotifications,
                                 content: `📣 A score report from ${submittingTeam ? submittingTeam.name : "a team"} has been approved by their opponent and is ready for staff approval\n${matchLink}/score-reporting`,
                                 success: async (mapObject : MapObject) => {
                                     await updateRecord(Cache, "Reports", report, {
                                         "Message Data": mapObject.textMap
-                                    });
+                                    }, "automation/on-score-report-update");
                                 }
                             });
 
@@ -190,7 +210,7 @@ export default {
                         console.log("Report has been counted by opposing team");
                         console.log({oldData, newData: report});
 
-                        messageData = await looseDeleteMessage(messageData, "opponent_captain_notification");
+                        messageData = await looseDeleteRecordedMessage<ScoreReportingReportKeys>(messageData, "report_opponent_notification");
 
                         // tell opponent
                         if (client &&
@@ -201,8 +221,8 @@ export default {
                             const discordControl = new MapObject(submittingTeam.discord_control);
                             const originalPing = discordControl.get("role_id") ? `<@&${discordControl.get("role_id")}>` : submittingTeam.name;
 
-                            messageData = await sendMessage({
-                                key: "original_captain_notification",
+                            messageData = await sendRecordedMessage<ScoreReportingReportKeys>({
+                                key: "report_opponent_notification",
                                 mapObject: messageData,
                                 channelID: eventSettings.logging.captainNotifications,
                                 content: `📣 ${originalPing}\nYour score report has been denied and countered by your opponent. Please check their submission to see if it is correct:\n${matchLink}/score-reporting`
@@ -214,16 +234,16 @@ export default {
                             eventSettings?.logging?.staffScoreReport &&
                             !report.approved_by_staff
                         ) {
-                            messageData = await looseDeleteMessage(messageData, "staff_notification");
-                            messageData = await sendMessage({
-                                key: "staff_notification",
+                            messageData = await looseDeleteRecordedMessage<ScoreReportingReportKeys>(messageData, "report_staff_notification");
+                            messageData = await sendRecordedMessage<ScoreReportingReportKeys>({
+                                key: "report_staff_notification",
                                 mapObject: messageData,
                                 channelID: eventSettings.logging.staffScoreReport,
                                 content: `📣 A score report from ${submittingTeam ? submittingTeam.name : "a team"} has been **denied and countered** by their opponent.\n${matchLink}/score-reporting`,
                                 success: async (mapObject : MapObject) => {
                                     await updateRecord(Cache, "Reports", report, {
                                         "Message Data": mapObject.textMap
-                                    });
+                                    }, "automation/on-score-report-update");
                                 }
                             });
                         }
@@ -258,8 +278,6 @@ export default {
                     const manager = getInternalManager();
                     if (!manager) return console.error("No internal manager can run automation action");
 
-                    messageData = await looseDeleteMessage(messageData, "opponent_reschedule_request");
-
                     try {
                         const { start } = JSON.parse(report.data);
                         if (start) {
@@ -273,8 +291,8 @@ export default {
 
                         // Delete record here (not implemented?)
                         console.log("Can now delete the score report");
-
-                        messageData = await looseDeleteMessage(messageData, "staff_reschedule_notification");
+                        // approval messages that need to be deleted
+                        messageData = await looseDeleteRecordedMessages<ReschedulingReportKeys>(messageData, ["reschedule_opponent_approval", "reschedule_staff_approval", "reschedule_staff_preapproval"]);
 
                         // #3 Teams pinged about reschedule
 
@@ -282,16 +300,19 @@ export default {
                             const discordControl = new MapObject(opponent?.discord_control);
                             return discordControl.get("role_id") ? `<@&${discordControl.get("role_id")}>` : opponent.name;
                         });
-                        messageData = await sendMessage({
-                            key: "reschedule_log",
+
+                        // remove old completion message
+                        messageData = await looseDeleteRecordedMessage<ReschedulingReportKeys>(messageData, "reschedule_completed");
+                        messageData = await sendRecordedMessage<ReschedulingReportKeys>({
+                            key: "reschedule_completed",
                             mapObject: messageData,
                             channelID: eventSettings.logging?.matchTimeChanges,
-                            content: `⌚ Match reschedule ${teamPings.join(" ")}: ${opponents.map(t => t.name || t.code).join(" vs ")} ${match.start ? "rescheduled to" : "scheduled for"} ${hammerTime(proposedStart)}.\n${matchLink}`
+                            content: `⌚ Match reschedule ${teamPings.join(" ")}: \n${opponents.map(t => t.name || t.code).join(" vs ")} ${match.start ? "rescheduled to" : "scheduled for"} ${hammerTime(proposedStart)}.\n${matchLink}`
                         });
                         await updateRecord(Cache, "Reports", report, {
                             "Approved": true,
                             "Message Data": messageData.textMap
-                        });
+                        }, "automation/on-score-report-update");
 
                     } catch (e) {
                         console.error("Action error - not continuing");
@@ -299,32 +320,158 @@ export default {
 
                 } else {
                     // Not ready to approve - see what changed though
+                    if (
+                        (!oldData.approved_by_team && report.approved_by_team) &&     // just submitted
+                        eventSettings.reporting.rescheduling.staffApprove &&          // staff approval required
+                        eventSettings.logging?.sendStaffPreapprovalNotifications &&   // staff pre approval messages enabled
+                        eventSettings.logging?.staffApprovalNotifications &&          // staff notification channel set up
+                        !report.approved_by_staff                                     // not yet approved by staff
+                    ) {
+                        // Send a pre-approval message
+                        console.log("Triggering pre-approval message for staff");
+                        messageData = await sendRecordedMessage<ReschedulingReportKeys>({
+                            key: "reschedule_staff_preapproval",
+                            mapObject: messageData,
+                            channelID: eventSettings.logging.staffApprovalNotifications,
+                            content: {
+                                content: "",
+                                embeds: [{
+                                    title: `${match.start ? "Reschedule" : "Schedule"} request: ${allTeams.map(t => t.name || t.code).join(" vs ")}`,
+                                    url: `${matchLink}/rescheduling`,
+                                    description: `${submittingTeam?.name ? `${submittingTeam.name} have` : "An opponent has"} ${match.start ? "requested a reschedule" : "requested a start time"} for the match.\nStaff approval is required, pre-approval is available now.`,
+                                    fields: [
+                                        {
+                                            name: "Proposed start time",
+                                            value: hammerTime(proposedStart),
+                                            inline: true
+                                        },
+                                        {
+                                            name: "Current start time",
+                                            value: match.start ? hammerTime(match.start) : "Not yet scheduled",
+                                            inline: true
+                                        }
+                                    ],
+                                    thumbnail: {
+                                        url: `${dataServer}/match.png?id=${cleanID(match.id)}&size=720&padding=30`,
+                                    },
+                                    color: eventColor
+                                }],
+                                components: [
+                                    {
+                                        type: 1,
+                                        components: [
+                                            new ButtonBuilder()
+                                                .setLabel("Pre-approve")
+                                                .setEmoji("<:shield_check:1322375448260247632>")
+                                                .setStyle(ButtonStyle.Primary)
+                                                .setCustomId(`reschedule_staff_approval/${cleanID(match.id)}/pre-approve`),
+                                            new ButtonBuilder()
+                                                .setLabel("Force approve")
+                                                .setEmoji("<:checksolidsq:1322072500082839623>")
+                                                .setStyle(ButtonStyle.Success)
+                                                .setCustomId(`reschedule_staff_approval/${cleanID(match.id)}/force-approve`),
+                                            new ButtonBuilder()
+                                                .setLabel("Deny")
+                                                .setEmoji("<:timessolidsq:1322072513697808504>")
+                                                .setStyle(ButtonStyle.Danger)
+                                                .setCustomId(`reschedule_staff_approval/${cleanID(match.id)}/deny`),
+                                            new ButtonBuilder()
+                                                .setLabel("Details")
+                                                .setStyle(ButtonStyle.Link)
+                                                .setURL(`${matchLink}/rescheduling`)
+                                        ]
+                                    }
+                                ]
+                            },
+                            success: async (mapObject: MapObject) => {
+                                await updateRecord(Cache, "Reports", report, {
+                                    "Message Data": mapObject.textMap
+                                }, "automation/on-score-report-update");
+                            }
+                        });
+                    }
 
                     if (
-                        (!oldData.approved_by_team && report.approved_by_team) &&   // just submitted
-                        eventSettings.reporting.rescheduling.opponentApprove &&     // opponent approval required
-                        !report.approved_by_opponent                                // not yet approved by opponent
+                        (!oldData.approved_by_team && report.approved_by_team) &&     // just submitted
+                        eventSettings.reporting.rescheduling.opponentApprove &&       // opponent approval required
+                        !report.approved_by_opponent                                  // not yet approved by opponent
                     ) {
-                        // #1 Opponent pinged about request
+                        // #1 Opponent approval request
+                        console.log("Opponent approval request");
 
                         const opponentPings = opponents.map(opponent => {
                             const discordControl = new MapObject(opponent?.discord_control);
                             return discordControl.get("role_id") ? `<@&${discordControl.get("role_id")}>` : opponent.name;
                         });
-                        messageData = await sendMessage({
-                            key: "opponent_reschedule_request",
-                            mapObject: messageData,
-                            channelID: eventSettings.logging?.captainNotifications,
-                            content: `📣 ${opponentPings.join(" ")}\n${submittingTeam?.name || "Your opponent"} ${match.start ? "has requested a reschedule to" : "requested a start time of"} ${hammerTime(proposedStart)}\n${matchLink}/rescheduling`,
-                            success: async (mapObject : MapObject) => {
-                                await updateRecord(Cache, "Reports", report, {
-                                    "Message Data": mapObject.textMap
-                                });
-                            }
-                        });
+
+
+                        if (eventSettings.logging?.captainNotifications) {
+                            messageData = await sendRecordedMessage<ReschedulingReportKeys>({
+                                key: "reschedule_opponent_approval",
+                                mapObject: messageData,
+                                channelID: eventSettings.logging?.captainNotifications,
+                                content: {
+                                    content: `📣 ${opponentPings.join(" ")}`,
+                                    embeds: [{
+                                        title: `${match.start ? "Reschedule" : "Schedule"} request: ${allTeams.map(t => t.name || t.code).join(" vs ")}`,
+                                        url: `${matchLink}/rescheduling`,
+                                        description: `${submittingTeam?.name ? `${submittingTeam.name} have` : "Your opponent has"} ${match.start ? "requested a reschedule" : "requested a start time"} for the match.`,
+                                        fields: [
+                                            {
+                                                name: "Proposed start time",
+                                                value: hammerTime(proposedStart),
+                                                inline: true
+                                            },
+                                            {
+                                                name: "Current start time",
+                                                value: match.start ? hammerTime(match.start) : "Not yet scheduled",
+                                                inline: true
+                                            }
+                                        ],
+                                        // author: {
+                                        //     name: event.name,
+                                        //     icon_url: eventTheme?.id ? `${dataServer}/theme.png?id=${cleanID(eventTheme?.id)}&size=500&padding=20` : null,
+                                        //     author_url: `https://${subdomain}slmn.gg/event/${cleanID(event.id)}`
+                                        // },
+                                        thumbnail: {
+                                            url: `${dataServer}/match.png?id=${cleanID(match.id)}&size=720&padding=30`,
+                                        },
+                                        color: eventColor
+                                    }],
+                                    components: [
+                                        {
+                                            type: 1,
+                                            components: [
+                                                new ButtonBuilder()
+                                                    .setLabel("Approve")
+                                                    .setEmoji("<:checksolidsq:1322072500082839623>")
+                                                    .setStyle(ButtonStyle.Success)
+                                                    .setCustomId(`reschedule_opponent_approval/${cleanID(match.id)}/approve`),
+                                                new ButtonBuilder()
+                                                    .setLabel("Deny")
+                                                    .setEmoji("<:timessolidsq:1322072513697808504>")
+                                                    .setStyle(ButtonStyle.Danger)
+                                                    .setCustomId(`reschedule_opponent_approval/${cleanID(match.id)}/deny`),
+                                                new ButtonBuilder()
+                                                    .setLabel("Details")
+                                                    // .setEmoji("<:infocircle:1322010140916056225>")
+                                                    .setStyle(ButtonStyle.Link)
+                                                    .setURL(`${matchLink}/rescheduling`)
+                                            ]
+                                        }
+                                    ]
+                                },
+                                success: async (mapObject: MapObject) => {
+                                    await updateRecord(Cache, "Reports", report, {
+                                        "Message Data": mapObject.textMap
+                                    }, "automation/on-score-report-update");
+                                }
+                            });
+                        }
                     } else if (
                         (
-                            (!oldData.approved_by_team && report.approved_by_team && !eventSettings.reporting.rescheduling.opponentApprove) ||   // just submitted and opponent not required
+                            (!oldData.approved_by_team && report.approved_by_team &&
+                                !eventSettings.reporting.rescheduling.opponentApprove) ||   // just submitted and opponent not required
                             (!oldData.approved_by_opponent && report.approved_by_opponent) // or opponent approval just completed
                         ) &&
                         eventSettings.reporting.rescheduling.staffApprove &&     // staff approval required
@@ -333,14 +480,225 @@ export default {
                         // #2 Staff prompted about request
                         console.log("Staff prompt for request");
 
-                        messageData = await sendMessage({ mapObject: messageData,
-                            key: "staff_reschedule_notification",
-                            channelID: eventSettings.logging?.staffScoreReport,
-                            content: `📣 A reschedule request from ${submittingTeam ? submittingTeam.name : "a team"} requires staff approval\n${matchLink}/rescheduling`,
-                            success: async (mapObject : MapObject) => {
+                        messageData = await looseDeleteRecordedMessage<ReschedulingReportKeys>(messageData, "reschedule_staff_preapproval");
+                        messageData = await sendRecordedMessage<ReschedulingReportKeys>({
+                            key: "reschedule_staff_approval",
+                            mapObject: messageData,
+                            channelID: eventSettings.logging?.staffApprovalNotifications,
+                            content: {
+                                content: "",
+                                embeds: [{
+                                    title: `${match.start ? "Reschedule" : "Schedule"} request: ${allTeams.map(t => t.name || t.code).join(" vs ")}`,
+                                    url: `${matchLink}/rescheduling`,
+                                    description: `${submittingTeam?.name ? `${submittingTeam.name} have` : "An opponent has"} ${match.start ? "requested a reschedule" : "requested a start time"} for the match.\nStaff approval is required.`,
+                                    fields: [
+                                        {
+                                            name: "Proposed start time",
+                                            value: hammerTime(proposedStart),
+                                            inline: true
+                                        },
+                                        {
+                                            name: "Current start time",
+                                            value: match.start ? hammerTime(match.start) : "Not yet scheduled",
+                                            inline: true
+                                        }
+                                    ],
+                                    thumbnail: {
+                                        url: `${dataServer}/match.png?id=${cleanID(match.id)}&size=720&padding=30`,
+                                    },
+                                    color: eventColor
+                                }],
+                                components: [
+                                    {
+                                        type: 1,
+                                        components: [
+                                            new ButtonBuilder()
+                                                .setLabel("Approve")
+                                                .setEmoji("<:checksolidsq:1322072500082839623>")
+                                                .setStyle(ButtonStyle.Success)
+                                                .setCustomId(`reschedule_staff_approval/${cleanID(match.id)}/approve`),
+                                            new ButtonBuilder()
+                                                .setLabel("Deny")
+                                                .setEmoji("<:timessolidsq:1322072513697808504>")
+                                                .setStyle(ButtonStyle.Danger)
+                                                .setCustomId(`reschedule_staff_approval/${cleanID(match.id)}/deny`),
+                                            new ButtonBuilder()
+                                                .setLabel("Details")
+                                                .setStyle(ButtonStyle.Link)
+                                                .setURL(`${matchLink}/rescheduling`)
+                                        ]
+                                    }
+                                ]
+                            },
+                            success: async (mapObject: MapObject) => {
                                 await updateRecord(Cache, "Reports", report, {
                                     "Message Data": mapObject.textMap
-                                });
+                                }, "automation/on-score-report-update");
+                            }
+                        });
+                    } else if (
+                        eventSettings.reporting.rescheduling.opponentApprove && // opponent approval required
+                        (!oldData.denied_by_opponent && report.denied_by_opponent) && // just denied by opponent
+                        client && eventSettings?.logging?.captainNotifications
+                    ) {
+                        // opponent denial
+                        console.log("Just Denied");
+                        messageData = await looseDeleteRecordedMessages<ReschedulingReportKeys>(messageData, ["reschedule_opponent_approval", "reschedule_staff_approval", "reschedule_staff_preapproval"]);
+
+                        const teamPings = allTeams.map(opponent => {
+                            const discordControl = new MapObject(opponent?.discord_control);
+                            return discordControl.get("role_id") ? `<@&${discordControl.get("role_id")}>` : opponent.name;
+                        });
+
+                        const opponentNames = opponents.map(opponent => opponent.name || opponent.code).join(" & ");
+
+                        console.log("Message send start");
+                        messageData = await sendRecordedMessage<ReschedulingReportKeys>({
+                            key: "reschedule_opponent_denial",
+                            mapObject: messageData,
+                            channelID: eventSettings.logging?.captainNotifications,
+                            content: {
+                                content: `📣 ${teamPings.join(" ")}`,
+                                embeds:  match.start ? [{
+                                    title: `Reschedule request denied: ${allTeams.map(t => t.name || t.code).join(" vs ")}`,
+                                    url: `${matchLink}/rescheduling`,
+                                    description: `<:danger_exclamation_circle:1322072455346655334> ${opponentNames ? `${opponentNames} have` : "Your opponent has"} denied a reschedule for the match.\nYou can start a new request on SLMN.GG.`,
+                                    fields: [
+                                        {
+                                            name: "Match start time",
+                                            value: `The match has **not been rescheduled** and is still set for ${hammerTime(match.start)}`
+                                        },
+                                        {
+                                            name: "Proposed start time",
+                                            value: hammerTime(proposedStart),
+                                            inline: true
+                                        },
+
+                                    ],
+                                    thumbnail: {
+                                        url: `${dataServer}/match.png?id=${cleanID(match.id)}&size=720&padding=30`,
+                                    },
+                                    color: parseInt("dc3545", 16)
+                                }] : [{
+                                    title: `Schedule request denied: ${allTeams.map(t => t.name || t.code).join(" vs ")}`,
+                                    url: `${matchLink}/rescheduling`,
+                                    description: `<:danger_exclamation_circle:1322072455346655334> ${opponentNames ? `${opponentNames} have` : "Your opponent has"} denied the requested start time for the match.\nYou can start a new request on SLMN.GG.`,
+                                    fields: [
+                                        {
+                                            name: "Match start time",
+                                            value: "The match has **not been scheduled**.",
+                                            inline: true
+                                        },
+                                        {
+                                            name: "Proposed start time",
+                                            value: hammerTime(proposedStart),
+                                            inline: true
+                                        },
+                                    ],
+                                    thumbnail: {
+                                        url: `${dataServer}/match.png?id=${cleanID(match.id)}&size=720&padding=30`,
+                                    },
+                                    color: parseInt("dc3545", 16)
+                                }],
+                                components: [
+                                    {
+                                        type: 1,
+                                        components: [
+                                            new ButtonBuilder()
+                                                .setLabel("Details")
+                                                // .setEmoji("<:infocircle:1322010140916056225>")
+                                                .setStyle(ButtonStyle.Link)
+                                                .setURL(`${matchLink}/rescheduling`)
+                                        ]
+                                    }
+                                ]
+                            },
+                            success: async (mapObject) => {
+                                console.log("Message send success", mapObject.data);
+                                await updateRecord(Cache, "Reports", report, {
+                                    "Message Data": mapObject.textMap
+                                }, "automation/on-score-report-update");
+                            }
+                        });
+                    } if (
+                        (!oldData.denied_by_staff && report.denied_by_staff) && // just denied by staff
+                        client && eventSettings?.logging?.captainNotifications
+                    ) {
+                        // opponent denial
+                        console.log("Just Denied by staff");
+                        messageData = await looseDeleteRecordedMessages<ReschedulingReportKeys>(messageData, ["reschedule_opponent_approval", "reschedule_staff_approval", "reschedule_staff_preapproval", "reschedule_opponent_denial"]);
+
+                        const teamPings = allTeams.map(opponent => {
+                            const discordControl = new MapObject(opponent?.discord_control);
+                            return discordControl.get("role_id") ? `<@&${discordControl.get("role_id")}>` : opponent.name;
+                        });
+
+                        console.log("Message send start");
+                        messageData = await sendRecordedMessage<ReschedulingReportKeys>({
+                            key: "reschedule_staff_denial",
+                            mapObject: messageData,
+                            channelID: eventSettings.logging?.captainNotifications,
+                            content: {
+                                content: `📣 ${teamPings.join(" ")}`,
+                                embeds:  match.start ? [{
+                                    title: `Reschedule request denied: ${allTeams.map(t => t.name || t.code).join(" vs ")}`,
+                                    url: `${matchLink}/rescheduling`,
+                                    description: "<:danger_exclamation_circle:1322072455346655334> Staff have denied a reschedule for the match.\nRescheduling for this match has been locked, contact staff for more information.",
+                                    fields: [
+                                        {
+                                            name: "Match start time",
+                                            value: `The match has **not been rescheduled** and is still set for ${hammerTime(match.start)}`
+                                        },
+                                        {
+                                            name: "Proposed start time",
+                                            value: hammerTime(proposedStart),
+                                            inline: true
+                                        },
+
+                                    ],
+                                    thumbnail: {
+                                        url: `${dataServer}/match.png?id=${cleanID(match.id)}&size=720&padding=30`,
+                                    },
+                                    color: parseInt("dc3545", 16)
+                                }] : [{
+                                    title: `Schedule request denied: ${allTeams.map(t => t.name || t.code).join(" vs ")}`,
+                                    url: `${matchLink}/rescheduling`,
+                                    description: "<:danger_exclamation_circle:1322072455346655334> Staff have denied the requested start time for the match.\nScheduling for this match has been locked, contact staff for more information.",
+                                    fields: [
+                                        {
+                                            name: "Match start time",
+                                            value: "The match has **not been scheduled**.",
+                                            inline: true
+                                        },
+                                        {
+                                            name: "Proposed start time",
+                                            value: hammerTime(proposedStart),
+                                            inline: true
+                                        },
+                                    ],
+                                    thumbnail: {
+                                        url: `${dataServer}/match.png?id=${cleanID(match.id)}&size=720&padding=30`,
+                                    },
+                                    color: parseInt("dc3545", 16)
+                                }],
+                                components: [
+                                    {
+                                        type: 1,
+                                        components: [
+                                            new ButtonBuilder()
+                                                .setLabel("Details")
+                                                // .setEmoji("<:infocircle:1322010140916056225>")
+                                                .setStyle(ButtonStyle.Link)
+                                                .setURL(`${matchLink}/rescheduling`)
+                                        ]
+                                    }
+                                ]
+                            },
+                            success: async (mapObject) => {
+                                console.log("Message send success", mapObject.data);
+                                await updateRecord(Cache, "Reports", report, {
+                                    "Message Data": mapObject.textMap
+                                }, "automation/on-score-report-update");
                             }
                         });
                     } else {

--- a/server/src/automation/on-score-report-update.ts
+++ b/server/src/automation/on-score-report-update.ts
@@ -25,7 +25,7 @@ const dataServer = process.env.NODE_ENV === "development" ? "http://localhost:89
 
 export default {
     async handler({ id, newData: report, oldData }: { id: AnyAirtableID, newData: Report, oldData: Report }) {
-        // if (!process.env.IS_SLMNGG_MAIN_SERVER) return;
+        if (!process.env.IS_SLMNGG_MAIN_SERVER) return;
         if (report?.__tableName !== "Reports") return;
         if (report.approved) {
             console.log("Already approved");

--- a/server/src/cache.js
+++ b/server/src/cache.js
@@ -411,6 +411,7 @@ async function getTwitchAccessToken(channel) {
     // get stored access token, check if it's valid
     // otherwise / or if no token, get from refresh token
     if (!channel) return null;
+    // TODO: put this in a different map to help with typing
     let storedToken = authMap.get(`twitch_access_token_${channel.channel_id}`);
 
     if (!storedToken || accessTokenIsExpired(storedToken)) {

--- a/server/src/discord/auth.js
+++ b/server/src/discord/auth.js
@@ -151,7 +151,7 @@ export default ({ app, router, cors, Cache }) => {
 
         if (airtable && ![discord.username, `${discord.username}#${discord.discriminator}`].includes(airtable.discord_tag)) {
             const updatedUsername = discord.discriminator === "0" ? discord.username : `${discord.username}#${discord.discriminator}`;
-            await updateRecord(Cache, "Players", airtable, { "Discord Tag": updatedUsername });
+            await updateRecord(Cache, "Players", airtable, { "Discord Tag": updatedUsername }, "discord/auth");
         }
 
         return { discord, airtable };

--- a/server/src/discord/commands/admin/set-user-id.js
+++ b/server/src/discord/commands/admin/set-user-id.js
@@ -1,8 +1,11 @@
 import {
     ActionRowBuilder,
-    ApplicationCommandType, ButtonBuilder, ButtonStyle,
+    ApplicationCommandType,
+    ButtonBuilder,
+    ButtonStyle,
     ContextMenuCommandBuilder,
-    StringSelectMenuBuilder, StringSelectMenuOptionBuilder,
+    StringSelectMenuBuilder,
+    StringSelectMenuOptionBuilder,
     userMention
 } from "discord.js";
 import * as Cache from "../../../cache.js";
@@ -85,7 +88,7 @@ export default {
 
         const internalManager = getInternalManager();
         if (!internalManager) {
-            return interaction.followUp({ ephemeral, content: "No action handlers can process your request." });
+            return interaction.followUp({ ephemeral, content: "Could not handle this request (no internal system available)" });
         }
 
         const potentials = await internalManager.runAction("match-discord-slmngg-player", { discordData: interaction.targetUser }, token);

--- a/server/src/discord/commands/prod/webcam.js
+++ b/server/src/discord/commands/prod/webcam.js
@@ -41,7 +41,7 @@ export default {
 
         const internalManager = getInternalManager();
         if (!internalManager) {
-            return interaction.editReply(startingPing + "No action handlers can process your request.");
+            return interaction.editReply(startingPing + "Could not handle this request (no internal system available)");
         }
 
         await internalManager.runAction("create-live-guest", {}, token)

--- a/server/src/discord/interactions.ts
+++ b/server/src/discord/interactions.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import path from "node:path";
+import { Collection, Events, InteractionType, MessageComponentInteraction } from "discord.js";
+import client from "./client.js";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const DIRNAME = path.dirname(fileURLToPath(import.meta.url));
+
+if (client) {
+    const interactions = new Collection();
+    const foldersPath = path.join(DIRNAME, "interactions");
+    const commandFolders = fs.readdirSync(foldersPath);
+
+    console.log("[interactions] loading interactions");
+
+    for (const folder of commandFolders) {
+        const commandsPath = path.join(foldersPath, folder);
+        const commandFiles = fs.readdirSync(commandsPath).filter(file => file.endsWith(".js") || file.endsWith(".ts"));
+        for (const file of commandFiles) {
+            const filePath = path.join(commandsPath, file);
+            const { default: command } = await import(pathToFileURL(filePath));
+            // Set a new item in the Collection with the key as the command name and the value as the exported module
+            if ("execute" in command) {
+                const commandName = command?.data?.name || [folder, (path.basename(filePath).replace(/\.(js|ts)$/, ""))].join("_");
+                console.log("~/", commandName);
+
+                interactions.set(commandName, command);
+            } else {
+                console.log(`[WARNING] The command at ${filePath} is missing a required "data" or "execute" property.`);
+            }
+        }
+    }
+
+    async function respond(interaction: MessageComponentInteraction, response: string, isError = false) {
+        if (isError) {
+            response = `<:danger_exclamation_circle:1322072455346655334> ${response}`;
+        } else {
+            response = `<:success_check_circle:1322072439718416466> ${response}`;
+        }
+        if (!response.trim().endsWith(".")) response += ".";
+
+        try {
+            if (interaction.replied || interaction.deferred) {
+                await interaction.followUp({
+                    content: response,
+                    ephemeral: true
+                });
+            } else {
+                await interaction.reply({
+                    content: response,
+                    ephemeral: true
+                });
+            }
+        } catch (e) {
+            console.error("Error sending follow up/reply to interaction", e);
+        }
+    }
+
+    client.on(Events.InteractionCreate, async (interaction) => {
+        // console.dir(interaction, { depth: null });
+
+        if (interaction.type !== InteractionType.MessageComponent) return;
+        const [id, ...args] = interaction.customId.split("/");
+        const command = interactions.get(id);
+
+
+        if (!command) {
+            if (id) console.error(`No interaction matching ID ${id} was found.`, { id, args });
+            return await respond(interaction, "Unknown command", true);
+        }
+
+        try {
+            const response = await command.execute(interaction, args);
+            // console.log("Interaction execute response", response, response.error);
+            if (response?.error) {
+                throw response.error;
+            } else if (response) {
+                await respond(interaction, response);
+            }
+            // console.log({ replied: interaction.replied, deferred: interaction.deferred });
+        } catch (error: any) {
+            console.error(error);
+            const errorMessage = typeof error === "string" ? error : (error.errorMessage || error.message);
+            await respond(interaction, errorMessage, true);
+        }
+    });
+} else {
+    console.warn("Discord interactions will not be set up because no Discord key is set.");
+}

--- a/server/src/discord/interactions/reschedule/opponent_approval.ts
+++ b/server/src/discord/interactions/reschedule/opponent_approval.ts
@@ -1,11 +1,10 @@
-import { Interaction, InteractionType, } from "discord.js";
 import { MatchResolvableID } from "../../../types.js";
 import * as Cache from "../../../cache.js";
 import { getInternalManager } from "../../../action-utils/action-manager.js";
+import { InteractionHandler } from "../../interactions.js";
 
 export default {
-    execute: async (interaction: Interaction, args: string[]) => {
-        if (interaction.type !== InteractionType.MessageComponent) return;
+    execute: async (interaction, args) => {
 
         // auth through discord
         const { token } = await Cache.auth.startRawDiscordAuth(interaction.user);
@@ -29,4 +28,4 @@ export default {
             return managerResponse;
         }
     }
-};
+} satisfies InteractionHandler;

--- a/server/src/discord/interactions/reschedule/opponent_approval.ts
+++ b/server/src/discord/interactions/reschedule/opponent_approval.ts
@@ -1,0 +1,32 @@
+import { Interaction, InteractionType, } from "discord.js";
+import { MatchResolvableID } from "../../../types.js";
+import * as Cache from "../../../cache.js";
+import { getInternalManager } from "../../../action-utils/action-manager.js";
+
+export default {
+    execute: async (interaction: Interaction, args: string[]) => {
+        if (interaction.type !== InteractionType.MessageComponent) return;
+
+        // auth through discord
+        const { token } = await Cache.auth.startRawDiscordAuth(interaction.user);
+        if (!token) throw "Could not authenticate you with SLMN.GG.";
+
+        const matchID = args[0] as MatchResolvableID;
+        const action = args[1] as "approve" | "deny";
+
+        console.log("approval", { matchID, action }, interaction.message);
+
+        const internalManager = getInternalManager();
+        if (!internalManager) {
+            throw "Could not handle this request (no internal system available)";
+        }
+        const managerResponse = await internalManager.runAction("approve-match-reschedule", { matchID: matchID, reaction: action }, token);
+        console.log(managerResponse);
+
+        if (managerResponse?.error) {
+            throw managerResponse.error;
+        } else {
+            return managerResponse;
+        }
+    }
+};

--- a/server/src/discord/interactions/reschedule/staff_approval.ts
+++ b/server/src/discord/interactions/reschedule/staff_approval.ts
@@ -1,12 +1,10 @@
-import { Interaction, InteractionType, } from "discord.js";
 import { MatchResolvableID } from "../../../types.js";
 import * as Cache from "../../../cache.js";
 import { getInternalManager } from "../../../action-utils/action-manager.js";
+import { InteractionHandler } from "../../interactions.js";
 
 export default {
-    execute: async (interaction: Interaction, args: string[]) => {
-        if (interaction.type !== InteractionType.MessageComponent) return;
-
+    execute: async (interaction, args) => {
         // auth through discord
         const { token } = await Cache.auth.startRawDiscordAuth(interaction.user);
         if (!token) throw "Could not authenticate you with SLMN.GG.";
@@ -29,4 +27,4 @@ export default {
             return managerResponse;
         }
     }
-};
+} satisfies InteractionHandler;

--- a/server/src/discord/interactions/reschedule/staff_approval.ts
+++ b/server/src/discord/interactions/reschedule/staff_approval.ts
@@ -1,0 +1,32 @@
+import { Interaction, InteractionType, } from "discord.js";
+import { MatchResolvableID } from "../../../types.js";
+import * as Cache from "../../../cache.js";
+import { getInternalManager } from "../../../action-utils/action-manager.js";
+
+export default {
+    execute: async (interaction: Interaction, args: string[]) => {
+        if (interaction.type !== InteractionType.MessageComponent) return;
+
+        // auth through discord
+        const { token } = await Cache.auth.startRawDiscordAuth(interaction.user);
+        if (!token) throw "Could not authenticate you with SLMN.GG.";
+
+        const matchID = args[0] as MatchResolvableID;
+        const action = args[1] as "approve" | "pre-approve" | "force-approve" | "deny" | "delete";
+
+        console.log("approval", { matchID, action }, interaction.message);
+
+        const internalManager = getInternalManager();
+        if (!internalManager) {
+            throw "Could not handle this request (no internal system available)";
+        }
+        const managerResponse = await internalManager.runAction("staff-approve-match-reschedule", { matchID: matchID, reaction: action }, token);
+        console.log(managerResponse);
+
+        if (managerResponse?.error) {
+            throw managerResponse.error;
+        } else {
+            return managerResponse;
+        }
+    }
+};

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -61,6 +61,7 @@ const Cache = (await import("./cache.js")).setup(io);
 actions.load(app, localCors, Cache, io);
 
 await import("./discord/slash-commands.js");
+await import("./discord/interactions.ts");
 await import("./automation-manager.js");
 
 app.use(express.urlencoded({ extended: true, limit: "50mb" }));

--- a/server/src/routes.js
+++ b/server/src/routes.js
@@ -441,7 +441,7 @@ export default ({ app, Cache, io }) => {
                     "Channel ID": tokenInfo.userId,
                     "Name": tokenInfo.userName,
                     "Stream Key": streamKey || undefined
-                });
+                }, "routes/twitch_callback");
 
             } else {
                 airtableResponse = await createRecord(Cache, "Channels", [{
@@ -450,7 +450,7 @@ export default ({ app, Cache, io }) => {
                     "Channel ID": tokenInfo.userId,
                     "Name": tokenInfo.userName,
                     "Stream Key": streamKey || undefined
-                }]);
+                }], "routes/twitch_callback");
             }
 
             // console.log(airtableResponse);

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -190,6 +190,42 @@ export interface Report extends Base {
     player?: PlayerResolvableID[];
     team?: TeamResolvableID[];
 }
+
+// export type ReschedulingReportMessageTypes =
+//       "reschedule_opponent_approval"
+//     | "reschedule_staff_preapproval"
+//     | "reschedule_staff_approval"
+//
+//     | "reschedule_completed"
+//
+//     | "reschedule_opponent_denial"
+//     | "reschedule_staff_denial"
+//     | "reschedule_team_cancel"
+//     | "reschedule_opponent_cancel" // unlikely to use this
+
+const ReschedulingReportMessageTypes = [
+    "reschedule_opponent_approval",
+    "reschedule_staff_preapproval",
+    "reschedule_staff_approval",
+    "reschedule_completed",
+    "reschedule_opponent_denial",
+    "reschedule_staff_denial",
+    "reschedule_team_cancel",
+    "reschedule_opponent_cancel",
+] as const;
+
+export type ReschedulingReportKeys = (typeof ReschedulingReportMessageTypes)[number];
+
+
+const ScoreReportingMessageTypes = [
+    "report_staff_notification",
+    "report_opponent_notification",
+    "report_completed_public",
+    "report_completed_staff"
+] as const;
+
+export type ScoreReportingReportKeys = (typeof ScoreReportingMessageTypes)[number];
+
 interface LogFile extends Base {
 
 }
@@ -229,8 +265,53 @@ interface AdRead extends Base {
 interface LiveGuest extends Base {
 
 }
-interface Theme extends Base {
+export interface Theme extends Base {
+    id: ThemeResolvableID;
+    __tableName: "Themes";
 
+    event?: EventResolvableID[];
+    events_as_title_sponsor?: EventResolvableID[];
+    live_guests?: LiveGuestResolvableID[];
+    team?: TeamResolvableID[];
+
+    team_blue?: TeamResolvableID[];
+    team_red?: TeamResolvableID[];
+    players?: PlayerResolvableID[];
+
+    name?: string;
+    description?: string;
+    desk_colors?: string;
+    available_for_factboxes?: boolean;
+
+    color_accent?: `#${string}`;
+    color_alt?: `#${string}`;
+    color_body?: `#${string}`;
+    color_dark?: `#${string}`;
+    color_gradient?: `#${string}`;
+    color_hero_recolor_primary?: `#${string}`;
+    color_hero_recolor_secondary?: `#${string}`;
+    color_logo_accent?: `#${string}`;
+    color_logo_background?: `#${string}`;
+    color_navbar?: `#${string}`;
+    color_text_on_body?: `#${string}`;
+    color_text_on_dark?: `#${string}`;
+    color_text_on_logo_background?: `#${string}`;
+    color_text_on_theme?: `#${string}`;
+    color_theme?: `#${string}`;
+    color_theme_on_dark?: `#${string}`;
+    color_website_active?: `#${string}`;
+    color_website_passive?: `#${string}`;
+
+    default_logo?: CacheAttachment[];
+    default_wordmark?: CacheAttachment[];
+    small_logo?: CacheAttachment[];
+
+    logo_on_dark?: CacheAttachment[];
+    logo_on_light?: CacheAttachment[];
+    logo_on_theme?: CacheAttachment[];
+    wordmark_on_dark?: CacheAttachment[];
+    wordmark_on_light?: CacheAttachment[];
+    wordmark_on_theme?: CacheAttachment[];
 }
 interface Accolade extends Base {
 
@@ -298,6 +379,7 @@ export interface Match extends Base {
     placeholder_teams?: string;
     player_relationships?: PlayerRelationshipResolvableID[];
     reports?: ReportResolvableID[];
+    report_history?: ReportResolvableID[];
     round?: string;
     schedule_text?: string;
     scheduled_broadcast?: string;
@@ -513,9 +595,12 @@ export type EventSettings = {
         matchTimeChanges?: Snowflake;
         postMatchReports?: Snowflake;
         captainNotifications?: Snowflake;
+
+        staffApprovalNotifications?: Snowflake;
         staffScoreReport?: Snowflake;
         staffCompletedScoreReport?: Snowflake;
 
+        sendStaffPreapprovalNotifications?: boolean;
         hideNonStaffRosterChanges?: boolean;
     }
 }

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -174,15 +174,17 @@ export interface Report extends Base {
     approved?: boolean;
     approved_by_team?: boolean;
     approved_by_opponent?: boolean;
+    denied_by_opponent?: boolean;
     countered_by_opponent?: boolean;
     approved_by_staff?: boolean;
+    denied_by_staff?: boolean;
     force_approved?: boolean;
 
     data?: string;
     countered_data?: string;
     message_data?: string;
     log?: string;
-    type?: "Scores" | "Attributes";
+    type?: "Scores" | "Attributes" | "Rescheduling";
 
     match?: MatchResolvableID[];
     player?: PlayerResolvableID[];
@@ -306,6 +308,8 @@ export interface Match extends Base {
     show_on_secondary_overlays?: boolean;
     special_event?: boolean;
     start?: string;
+    earliest_start?: string;
+    latest_start?: string;
     stats?: string;
     stream_code?: string;
     sub_event?: string;
@@ -497,6 +501,11 @@ export type EventSettings = {
             showHeroBans?: boolean;
             showMapBans?: boolean;
             allowForfeits?: boolean;
+        },
+        rescheduling: {
+            use?: boolean;
+            staffApprove?: boolean;
+            opponentApprove?: boolean;
         }
     };
     logging?: {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -539,9 +539,10 @@ export type AuthUserData = {
         airtable: Player;
     }
 }
+export type UserData = AuthUserData["user"];
 
 export type ActionAuth = {
-    user: AuthUserData["user"];
+    user: UserData;
     client?: Client;
     isAutomation?: boolean;
 }

--- a/website/src/components/broadcast/BroadcastMapDisplay.vue
+++ b/website/src/components/broadcast/BroadcastMapDisplay.vue
@@ -52,6 +52,9 @@ export default {
         audioStatus: "not playing"
     }),
     computed: {
+        /**
+         * @returns {Match|null}
+         */
         match() {
             if (this.virtualMatch) return this.virtualMatch;
             if (!this.broadcast?.live_match) return null;
@@ -137,7 +140,7 @@ export default {
             // maximum: current maps + however many to get a win
             //          or current + 1 if no winner
             // if (!this.match.maps) return this.match.first_to;
-            const scores = [this.match.score_1, this.match.score_2].map(s => s || 0);
+            const scores = [this.match.score_1, this.match.score_2].map(s => s);
 
             if (scores.some(s => s === this.match.first_to)) {
                 // match complete

--- a/website/src/components/broadcast/cams/CamsWrapper.vue
+++ b/website/src/components/broadcast/cams/CamsWrapper.vue
@@ -42,7 +42,7 @@ export default {
         },
         stringify(obj) {
             if (!obj) return "";
-            return "&" + Object.entries(obj).map(item => item.filter(x => x).join("=")).join("&");
+            return "&" + Object.entries(obj).map(item => item.filter(Boolean).join("=")).join("&");
         }
     }
 };

--- a/website/src/components/website/LoggedInUser.vue
+++ b/website/src/components/website/LoggedInUser.vue
@@ -20,6 +20,7 @@
         <b-dropdown-divider v-if="isProduction" />
         <b-dropdown-item v-if="isProduction" v-b-modal.token-modal variant="dark">Token</b-dropdown-item>
         <b-dropdown-item v-if="isProduction" variant="dark" to="/login">Re-authenticate</b-dropdown-item>
+        <b-dropdown-item v-if="siteMode && siteMode !== 'production'" variant="dark" @click="handleLogout">Logout</b-dropdown-item>
         <TokenModal />
     </b-nav-item-dropdown>
 </template>
@@ -44,6 +45,9 @@ export default {
         },
         avatar() {
             return bg(this.user.avatar);
+        },
+        siteMode() {
+            return import.meta.env.VITE_DEPLOY_MODE || import.meta.env.NODE_ENV;
         }
     },
     methods: {
@@ -58,6 +62,11 @@ export default {
         },
         rootLinkRouter(url) {
             return isOnMainDomain() ? url : null;
+        },
+        handleLogout() {
+            const auth = useAuthStore();
+            auth.logout();
+            this.$router.push("/");
         }
 
     }

--- a/website/src/components/website/LoggedInUser.vue
+++ b/website/src/components/website/LoggedInUser.vue
@@ -30,7 +30,7 @@ import { url } from "@/utils/content-utils.js";
 import { getMainDomain, isOnMainDomain } from "@/utils/fetch";
 import { bg } from "@/utils/images";
 import TokenModal from "@/components/website/dashboard/TokenModal.vue";
-import { mapState, mapWritableState } from "pinia";
+import { mapState } from "pinia";
 import { useAuthStore } from "@/stores/authStore";
 
 export default {

--- a/website/src/components/website/ReportLog.vue
+++ b/website/src/components/website/ReportLog.vue
@@ -1,0 +1,40 @@
+<template>
+    <div class="report-log">
+        <div v-for="step in steps" :key="step.key" class="step">
+            <span v-if="step.time">{{ step.time }}:&nbsp;</span>
+            <span v-if="step.user"><router-link :to="url('player', step.user)">{{ step.user?.name }}</router-link>&nbsp;</span>
+            <span v-if="step.text" class="action">{{ step.text.slice(0,1).toLowerCase() + step.text.slice(1) }}&nbsp;</span>
+            <span v-if="step.team">as <router-link :to="url('team', step.team)">{{ step.team?.name }}</router-link>&nbsp;</span>
+            <span v-else-if="step.staff">as staff&nbsp;</span>
+        </div>
+    </div>
+</template>
+
+<script>
+import { ReactiveRoot } from "@/utils/reactive.js";
+import { formatTime, url } from "@/utils/content-utils.js";
+
+export default {
+    name: "ReportLog",
+    props: {
+        log: String
+    },
+    computed: {
+        steps() {
+            return this.log.split("\n").map(step => Object.fromEntries(step.split("|").map(pair => pair.split("=")))).map(step => {
+
+                step.time = formatTime(new Date(parseInt(step.date)), { format: "{date-ordinal} {month-short} {time}"});
+                if (step.user) step.user = ReactiveRoot(step.user);
+                if (step.team) step.team = ReactiveRoot(step.team);
+                if (step.staff) step.staff = true;
+
+                return step;
+            });
+        }
+    },
+    methods: { url }
+};
+</script>
+
+<style scoped>
+</style>

--- a/website/src/components/website/ReportStepsTop.vue
+++ b/website/src/components/website/ReportStepsTop.vue
@@ -1,0 +1,128 @@
+<template>
+    <div class="report-steps-top bg-dark w-100">
+        <div v-if="title" class="steps-title">{{ title }}</div>
+        <div v-if="steps?.length" class="steps d-flex gap-3 p-2">
+            <div v-for="(step, i) in steps" :key="step.number" class="step d-flex flex-center flex-column gap-2 py-1" :class="`status-${step.status}`">
+                <!--                <div class="step-num fw-bold">{{ step.number }}</div>-->
+                <div class="step-icon-wrapper flex-center my-1">
+                    <div class="step-icon-holder flex-center">
+                        <div class="step-icon">
+                            <i :class="`fa-fw ${step.icon}`"></i>
+                        </div>
+                    </div>
+                    <div
+                        v-if="i !== steps.length-1"
+                        class="step-bar"
+                        :class="`status-${step.status === 'complete' ? 'complete' : 'waiting'} ${i <= steps.length - 1 && steps[i+1]?.status === 'disabled' ? 'next-disabled': ''}`">
+                    </div>
+                </div>
+                <div class="step-content flex-grow-1 text-center">
+                    <div class="step-title fw-bold mb-1">{{ step.title }}</div>
+                    <div class="step-description">{{ step.description }}</div>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+export default {
+    name: "ReportStepsTop",
+    props: {
+        steps: Array,
+        title: String
+    }
+};
+</script>
+
+<style scoped>
+    .report-steps-top {
+        border: 1px solid rgba(255,255,255,0.1);
+        border-radius: .5em;
+        overflow: hidden;
+    }
+    .steps-title {
+        font-weight: bold;
+        text-align: center;
+        font-size: 1.75em;
+        text-transform: uppercase;
+        padding: 0.1em;
+        border-bottom: 1px solid rgba(255,255,255,0.1);
+        background-color: rgba(255,255,255,0.05);
+    }
+    .step {
+        flex: 1 0;
+    }
+    .step-num {
+        font-size: 1.5em;
+        width: .75em;
+        text-align: center;
+    }
+    .step-icon {
+        font-size: 2em;
+    }
+    .step-icon-holder {
+        background-color: var(--variant-background-color, #383b3f);
+        color: var(--variant-color, #ffffff);
+        width:  4em;
+        height: 4em;
+        border-radius: 50%;
+        flex-shrink: 0;
+        z-index: 1;
+    }
+    .step-icon-wrapper {
+        position: relative;
+        width: 100%;
+    }
+
+    .step-bar {
+        position: absolute;
+        height: 1em;
+        width: 100%;
+        left: 50%;
+        background-color: #383b3f;
+    }
+    .status-complete .step-bar,
+    .status-countered .step-bar {
+        background-color: var(--variant-background-color, #383b3f);
+    }
+    .step-title {
+        font-size: 1.25em;
+        line-height: 1.1;
+    }
+    .step-description {
+        font-size: 0.9em;
+        line-height: 1.1;
+    }
+
+    /*.step.status-active {*/
+    /*    --variant-background-color: var(--primary);*/
+    /*}*/
+
+    .step.status-active .step-icon-holder {
+        border: .25em solid var(--primary);
+    }
+
+    .step.status-complete {
+        --variant-background-color: var(--green);
+    }
+    .step.status-denied,
+    .step.status-blocking {
+        --variant-background-color: var(--red);
+    }
+    .step.status-countered {
+        --variant-background-color: var(--yellow);
+        --variant-color: var(--dark);
+    }
+    .step.status-disabled, .step.status-disabled .step-icon {
+        --variant-background-color: #2c3034;
+        color: rgba(255,255,255,0.5);
+    }
+    .step-bar.next-disabled {
+        opacity: 0;
+    }
+
+    .step .step-icon i {
+        transform: translateY(-0.1em)
+    }
+</style>

--- a/website/src/components/website/WebsiteNav.vue
+++ b/website/src/components/website/WebsiteNav.vue
@@ -19,9 +19,10 @@
         <WebsiteNavBanner v-if="siteMode === 'staging'" class="bg-warning text-dark">
             <b><a href="https://github.com/slmnio/slmngg-sfc" class="text-dark">Beta development version:</a></b> things may break. Use <a href="https://slmn.gg" class="text-dark fw-bold">slmn.gg</a> for the latest stable update.
         </WebsiteNavBanner>
-        <WebsiteNavBanner v-if="siteMode === 'local'" class="text-light bg-primary">
+        <WebsiteNavBanner v-if="siteMode === 'local'" class="" :class="{'bg-light text-primary fw-bold': reloadAfterRebuild, 'bg-primary text-light': !reloadAfterRebuild}" @click="reloadAfterRebuild = !reloadAfterRebuild">
             <i v-if="dataServerMode !== 'local'" class="fas fa-exclamation-triangle fa-fw mr-1"></i>
             SLMN.GG is running in local development mode<strong v-if="dataServerMode !== 'local'"> but not using a local data server</strong>.
+            {{ reloadAfterRebuild ? 'Page will reload after data server rebuilds' : '' }}
         </WebsiteNavBanner>
         <!--       example: <WebsiteNavBanner class="bg-success" v-if="$socket.connected">Connected to the data server for live data updates!</WebsiteNavBanner>-->
 
@@ -127,7 +128,8 @@ export default {
     data: () => ({
         pageNoLongerNew: false,
         resizeObserver: null,
-        height: 0
+        height: 0,
+        reloadAfterRebuild: false
     }),
     computed: {
         ...mapWritableState(useAuthStore, ["user"]),
@@ -214,6 +216,13 @@ export default {
         },
         onResize() {
             this.height = this.$el.offsetHeight;
+        }
+    },
+    watch: {
+        isRebuilding(rebuilding) {
+            if (!rebuilding && this.reloadAfterRebuild) {
+                document.location.reload();
+            }
         }
     },
     mounted() {

--- a/website/src/components/website/dashboard/AdvancedDateEditor.vue
+++ b/website/src/components/website/dashboard/AdvancedDateEditor.vue
@@ -24,7 +24,7 @@
                 :model-value="temporaryTime || safeSavedTime"
                 @update:model-value="(val) => temporaryTime = val" />
 
-            <div class="earliest-latest-warning py-2 flex-center text-center bg-secondary my-2 text-white rounded" :class="{'bg-danger': isValid === false}">
+            <div class="earliest-latest-warning py-2 flex-center text-center my-2 border border-primary rounded" :class="{'bg-danger text-white': isValid === false}">
                 <div v-if="earliestTime && !latestTime">
                     This match must start at or after <b>{{ formatTime(earliestTime) }}</b>
                 </div>

--- a/website/src/components/website/dashboard/AdvancedDateEditor.vue
+++ b/website/src/components/website/dashboard/AdvancedDateEditor.vue
@@ -1,14 +1,14 @@
 <template>
     <div class="date-editor">
         <div class="date-editor-button">
-            <b-button v-b-modal.date-editor-modal :disabled="isProcessing">
+            <b-button v-b-modal.date-editor-modal :disabled="isProcessing" class="py-2 px-3">
                 <LoadingIcon v-if="isProcessing" />
                 <i v-else class="fas fa-fw fa-calendar-alt"></i>
                 <span v-if="$slots.default?.()" class="ml-1"><slot></slot></span>
             </b-button>
         </div>
 
-        <b-modal id="date-editor-modal" @ok="$emit('submit', airtableSafeDate)">
+        <b-modal id="date-editor-modal" :ok-disabled="isValid === false" @ok="$emit('submit', airtableSafeDate)">
             <template #modal-title>Time editor</template>
 
             <div class="d-flex mb-3 flex-center">
@@ -23,6 +23,28 @@
                 type="datetime-local"
                 :model-value="temporaryTime || safeSavedTime"
                 @update:model-value="(val) => temporaryTime = val" />
+
+            <div class="earliest-latest-warning py-2 flex-center text-center bg-secondary my-2 text-white rounded" :class="{'bg-danger': isValid === false}">
+                <div v-if="earliestTime && !latestTime">
+                    This match must start at or after <b>{{ formatTime(earliestTime) }}</b>
+                </div>
+                <div v-else-if="!earliestTime && latestTime">
+                    This match must start at or before <b>{{ formatTime(latestTime) }}</b>
+                </div>
+                <div v-else-if="earliestTime && latestTime">
+                    This match must start between <b>{{ formatTime(earliestTime) }}</b> and<br><b>{{ formatTime(latestTime) }}</b>
+                </div>
+            </div>
+
+            <div v-if="earliestTime || latestTime" class="earliest-latest-buttons flex-center mb-2">
+                <div v-if="earliestTime" class="left flex-shrink-0">
+                    <b-button variant="primary" size="sm" @click="temporaryTime = safeTime(earliestTime)"><i class="fas fa-arrow-to-left fa-fw mr-1"></i> Set to earliest</b-button>
+                </div>
+                <div class="flex-grow-1"></div>
+                <div v-if="latestTime" class="right flex-shrink-0">
+                    <b-button variant="primary" size="sm" @click="temporaryTime = safeTime(latestTime)">Set to latest <i class="fas fa-arrow-to-right fa-fw ml-1"></i></b-button>
+                </div>
+            </div>
 
             <div class="text-center mb-2">Editing in <b>{{ editTimeInSiteTimezone ? 'the site' : 'your local' }} timezone</b> ({{ timezoneName }})</div>
             <div class="flex-center text-center timezones">
@@ -49,13 +71,16 @@ import LoadingIcon from "@/components/website/LoadingIcon.vue";
 import { useSettingsStore } from "@/stores/settingsStore";
 import { mapWritableState } from "pinia";
 
+const SafeTimeFormat = "{year}-{iso-month}-{date-pad}T{hour-24-pad}:{minute-pad}:{second-pad}";
+
 export default {
     name: "AdvancedDateEditor",
     components: {
         LoadingIcon,
         TimezoneSwapper
     },
-    props: ["savedTime", "isProcessing"],
+    props: ["savedTime", "isProcessing", "earliestTime", "latestTime"],
+    emits: ["submit"],
     data: () => ({
         temporaryTime: null
     }),
@@ -65,7 +90,7 @@ export default {
             if (!this.savedTime || typeof this.savedTime !== "string") return null;
             let ref = spacetime(this.savedTime.replace("Z", ""), "UTC");
             ref = ref.goto(this.editTimeInSiteTimezone ? this.siteTimezone : this.localTimezone);
-            return ref.format("{year}-{iso-month}-{date-pad}T{hour-24-pad}:{minute-pad}:{second-pad}");
+            return ref.format(SafeTimeFormat);
         },
         spaceTimeRef() {
             const ref = spacetime(this.temporaryTime || this.safeSavedTime, this.editTimeInSiteTimezone ? this.siteTimezone : this.localTimezone);
@@ -87,10 +112,33 @@ export default {
         },
         airtableSafeDate() {
             return this.spaceTimeRef.toLocalDate().toISOString();
+        },
+        isValid() {
+            if (!this.temporaryTime) return null;
+            let numTime = spacetime(this.temporaryTime, this.editTimeInSiteTimezone ? this.siteTimezone : this.localTimezone).epoch;
+            if (this.earliestTime) {
+                let earliestEpoch = spacetime(this.earliestTime).epoch;
+                if (numTime < earliestEpoch) return false;
+            }
+            if (this.latestTime) {
+                let latestEpoch = spacetime(this.latestTime).epoch;
+                if (numTime > latestEpoch) return false;
+            }
+            return true;
         }
     },
     methods: {
-        formatTime
+        formatTime, spacetime,
+        safeTime(timeString) {
+            if (!timeString || typeof timeString !== "string") return null;
+            return this.formatTime(
+                timeString,
+                {
+                    tz: this.editTimeInSiteTimezone ? this.siteTimezone : this.localTimezone,
+                    format: SafeTimeFormat,
+                    use24HourTime: this.$store.state.use24HourTime }
+            );
+        }
     }
 };
 </script>

--- a/website/src/components/website/dashboard/BreakDisplayMultiModal.vue
+++ b/website/src/components/website/dashboard/BreakDisplayMultiModal.vue
@@ -78,10 +78,11 @@ import BreakTextTab from "@/components/website/dashboard/BreakTextTab.vue";
 import BreakTimeControls from "@/components/website/dashboard/BreakTimeControls.vue";
 import Squeezable from "@/components/broadcast/Squeezable.vue";
 import { authenticatedRequest } from "@/utils/dashboard";
+import Countdown from "@/components/broadcast/Countdown.vue";
 
 export default {
     name: "BreakDisplayMultiModal",
-    components: { Squeezable, BreakTimeControls, BreakTextTab, BreakAutomationTab, BreakDisplayTab },
+    components: { Countdown, Squeezable, BreakTimeControls, BreakTextTab, BreakAutomationTab, BreakDisplayTab },
     props: {
         broadcast: Object
     },

--- a/website/src/components/website/dashboard/BreakTimeControls.vue
+++ b/website/src/components/website/dashboard/BreakTimeControls.vue
@@ -90,7 +90,7 @@
 import { authenticatedRequest } from "@/utils/dashboard";
 import AdvancedDateEditor from "@/components/website/dashboard/AdvancedDateEditor.vue";
 import Countdown from "@/components/broadcast/Countdown.vue";
-import { formatTime } from "../../../utils/content-utils";
+import { formatTime } from "@/utils/content-utils.js";
 
 export default {
     name: "BreakTimeControls",

--- a/website/src/components/website/dashboard/HeroesPicker.vue
+++ b/website/src/components/website/dashboard/HeroesPicker.vue
@@ -45,7 +45,7 @@ export default {
                 { value: null, text: "No hero" },
                 ...(
                     this.game !== "Overwatch" ?
-                        (this.heroes || []).sort((a,b) => sortAlpha(a,b,"name")).map(h => ({
+                        (this.heroes || []).sort((a,b) => sortAlpha(a, b, "name")).map(h => ({
                             text: h.name,
                             value: dirtyID(h.id)
                         }))

--- a/website/src/components/website/dashboard/HeroesPicker.vue
+++ b/website/src/components/website/dashboard/HeroesPicker.vue
@@ -45,7 +45,7 @@ export default {
                 { value: null, text: "No hero" },
                 ...(
                     this.game !== "Overwatch" ?
-                        (this.heroes || []).sort((a,b) => sortAlpha(a?.name, b?.name)).map(h => ({
+                        (this.heroes || []).sort((a,b) => sortAlpha(a,b,"name")).map(h => ({
                             text: h.name,
                             value: dirtyID(h.id)
                         }))

--- a/website/src/components/website/dashboard/MatchEditor.vue
+++ b/website/src/components/website/dashboard/MatchEditor.vue
@@ -18,8 +18,11 @@
             <!--                <div class="spacer flex-grow-1"></div>-->
             <!--                <b-button :disabled="processing['map']" class="ml-5 top-button flex-shrink-0" variant="success" @click="() => saveMapAndScores()"><i class="fas fa-save fa-fw"></i> Save all</b-button>-->
             <div v-if="scoreReporting && proposedData" class="fill-buttons d-flex gap-2 justify-content-center mt-2">
-                <b-button variant="secondary" size="sm" @click="loadProposedData"><i class="fal fa-fw fa-upload"></i> Load proposed score report</b-button>
+                <b-button variant="primary" size="sm" @click="loadProposedData"><i class="fal fa-fw fa-upload"></i> Load proposed score report</b-button>
                 <b-button variant="danger" size="sm" @click="emptyData()"><i class="fas fa-trash fa-fw"></i> Empty editor</b-button>
+                <b-button v-if="scoreReporting" size="sm" @click="() => extraMaps++">
+                    <i class="fas fa-fw fa-plus"></i> Add map
+                </b-button>
             </div>
             <div class="teams-scores pt-2 px-2">
                 <div class="checkboxes">
@@ -48,19 +51,19 @@
                     :max="match.first_to"
                     class="opacity-changes score-input" />
                 <div class="spacer" style="order:10"></div>
-                <div class="right-buttons" style="order:11">
+                <div v-if="!scoreReporting" class="right-buttons" style="order:11">
                     <b-button size="sm" @click="() => extraMaps++">
                         <i class="fas fa-fw fa-plus"></i> Add map
                     </b-button>
-                    <b-button
-                        v-if="scoreReporting"
-                        class="top-button flex-shrink-0"
-                        variant="success"
-                        :disabled="!matchData.scores.some(s => s === match.first_to)"
-                        @click="() => scoreReportConfirmModal = true">
-                        <i class="fas fa-save fa-fw"></i> {{ scoreReportAction === "counter" ? 'Submit counter report' : "Submit score report" }}
-                    </b-button>
-                    <b-button v-else class="top-button flex-shrink-0" variant="success" @click="() => sendMapDataChange()"><i class="fas fa-save fa-fw"></i> Save {{ hideMatchExtras ? 'all' : 'maps' }}</b-button>
+                    <!--                    <b-button-->
+                    <!--                        v-if="scoreReporting"-->
+                    <!--                        class="top-button flex-shrink-0"-->
+                    <!--                        variant="success"-->
+                    <!--                        :disabled="!matchData.scores.some(s => s === match.first_to)"-->
+                    <!--                        @click="() => scoreReportConfirmModal = true">-->
+                    <!--                        <i class="fas fa-save fa-fw"></i> {{ scoreReportAction === "counter" ? 'Submit counter report' : "Submit score report" }}-->
+                    <!--                    </b-button>-->
+                    <b-button class="top-button flex-shrink-0" variant="success" @click="() => sendMapDataChange()"><i class="fas fa-save fa-fw"></i> Save {{ hideMatchExtras ? 'all' : 'maps' }}</b-button>
                 </div>
             </div>
             <div v-if="scoreReporting && showScoreReportForfeit" class="score-reporting-extras py-2">

--- a/website/src/components/website/schedule/ScheduleTime.vue
+++ b/website/src/components/website/schedule/ScheduleTime.vue
@@ -3,11 +3,20 @@
         <div v-if="customText" class="custom-text mt-1">{{ customText }}</div>
         <div v-if="top" class="top">{{ top }}</div>
         <div v-if="bottom" class="bottom">{{ bottom }}</div>
+        <router-link
+            v-if="badge"
+            v-b-tooltip.left
+            class="badge pill text-white"
+            :class="`bg-${badge.variant}`"
+            :title="badge?.title"
+            :to="url('match', this.match, { subPage: 'rescheduling' })">
+            <i class="far fa-clock mr-1"></i>{{ badge.text }}
+        </router-link>
     </div>
 </template>
 
 <script>
-import { formatTime } from "@/utils/content-utils";
+import { formatTime, url } from "@/utils/content-utils";
 import { useSettingsStore } from "@/stores/settingsStore";
 
 export default {
@@ -16,7 +25,9 @@ export default {
         time: [String, Number],
         customText: String,
         noTimes: Boolean,
-        customTimezone: String
+        customTimezone: String,
+        badge: Object,
+        match: Object
     },
     computed: {
         top() {
@@ -33,7 +44,8 @@ export default {
                 use24HourTime: useSettingsStore().use24HourTime
             });
         }
-    }
+    },
+    methods: { url }
 };
 </script>
 
@@ -46,5 +58,11 @@ export default {
         font-weight: bold;
         text-transform: uppercase;
         line-height: 1;
+    }
+    .badge {
+        font-weight: bold;
+        font-size: .7em;
+        text-transform: uppercase;
+        padding: 0.25em 0.5em;
     }
 </style>

--- a/website/src/router/shared-routes.js
+++ b/website/src/router/shared-routes.js
@@ -77,6 +77,7 @@ export default [
             { path: "", component: () => import("@/views/sub-views/MatchVOD.vue") },
             { path: "history", component: () => import("@/views/sub-views/MatchStats.vue") },
             { path: "score-reporting", component: () => import("@/views/sub-views/MatchScoreReporting.vue"), meta: { requiresAuth: true } },
+            { path: "rescheduling", component: () => import("@/views/sub-views/MatchRescheduling.vue"), meta: { requiresAuth: true } },
             { path: "editor", component: () => import("@/views/sub-views/event/EventMatchEditor.vue"), meta: { requiresAuth: true } }
         ]
     },

--- a/website/src/socket.js
+++ b/website/src/socket.js
@@ -11,7 +11,9 @@ export const socket = io(getDataServerAddress(), { transports: ["websocket", "po
 
 socket.on("connect", () => {
     state.connected = true;
-    socket.emit("subscribe-multiple", store.state.subscribed_ids);
+    if (store.state.subscribed_ids?.length) {
+        socket.emit("subscribe-multiple", store.state.subscribed_ids);
+    }
 });
 
 socket.on("disconnect", () => {

--- a/website/src/stores/authStore.ts
+++ b/website/src/stores/authStore.ts
@@ -165,6 +165,12 @@ export const useAuthStore = defineStore("auth", () => {
         };
     }
 
+    function logout() {
+        token.value = null;
+        user.value = null;
+        authNext.value = null;
+    }
+
     return {
         token,
         authNext,
@@ -178,7 +184,8 @@ export const useAuthStore = defineStore("auth", () => {
         authenticateWithDiscord,
         setAuthNext,
         getAuthNext,
-        authenticateWithToken
+        authenticateWithToken,
+        logout
     };
 }, {
     persist: {

--- a/website/src/utils/content-utils.js
+++ b/website/src/utils/content-utils.js
@@ -673,7 +673,7 @@ export function decoratePlayerWithDraftData(player, eventID) {
 }
 
 
-export function getScoreReportingBadge(state, report, eventSettings) {
+export function getScoreReportingBadge(state, report, eventSettings, type = "score-reporting") {
     if (!state.reports_enabled) return null;
     if (state.is_complete) return null;
 

--- a/website/src/utils/content-utils.js
+++ b/website/src/utils/content-utils.js
@@ -119,7 +119,7 @@ export function multiImage(theme, keys, minSize = 30, useResizer = true) {
 }
 
 export function getMatchContext(match, { light } = {}) {
-    let pieces = [];
+    let pieces;
     if (light) {
         pieces = [match?.sub_event].filter(Boolean);
     } else {

--- a/website/src/utils/dashboard.ts
+++ b/website/src/utils/dashboard.ts
@@ -273,7 +273,11 @@ export async function authenticatedRequest<U extends RequestUrl>(url: U, data?: 
             },
             body: JSON.stringify(data ?? {})
         }).then(async res => await res.json()).catch((error: Error) => {
-            notyf.error({ message: `Request error: ${error.message}` });
+            if (error.message === "Failed to fetch") {
+                notyf.error({ message: "Request failed: connection error" });
+            } else {
+                notyf.error({ message: `Request error: ${error.message}` });
+            }
             console.error("Fetch error", error);
         });
         console.log(request);

--- a/website/src/views/BracketCreator.vue
+++ b/website/src/views/BracketCreator.vue
@@ -101,7 +101,7 @@
                                             class="connection-button"
                                             :class="{
                                                 'active': activeConnectionMatches(bi, ci, mi, 'win') || getConnection(bi, ci, mi, 'win'),
-                                                'champion':getConnection(bi, ci, mi, 'win') === 'champion',
+                                                'champion':getConnection(bi, ci, mi, 'win') === 'champion'
                                             }"
                                             @mouseenter="showConnection(bi, ci, mi, 'win')"
                                             @mouseleave="hideConnection()"
@@ -113,7 +113,7 @@
                                             class="connection-button"
                                             :class="{
                                                 'active': activeConnectionMatches(bi, ci, mi, 'lose') || getConnection(bi, ci, mi, 'lose'),
-                                                'eliminated':getConnection(bi, ci, mi, 'lose') === 'eliminated',
+                                                'eliminated':getConnection(bi, ci, mi, 'lose') === 'eliminated'
                                             }"
                                             @mouseenter="showConnection(bi, ci, mi, 'lose')"
                                             @mouseleave="hideConnection()"

--- a/website/src/views/Match.vue
+++ b/website/src/views/Match.vue
@@ -4,7 +4,7 @@
         <div v-if="match.special_event ? [match.score_1, match.score_2].some(x => x) : true" class="container mt-3 text-center">
             <MatchScore :match="match" />
         </div>
-        <div class="container mt-3 large-container">
+        <div class="container-fluid container-lg mt-3 large-container">
             <div class="row">
                 <div class="col-12 col-lg-9 mb-3">
                     <router-view :match="match" />
@@ -98,7 +98,13 @@ import { ReactiveArray, ReactiveRoot, ReactiveThing } from "@/utils/reactive";
 import MatchHero from "@/components/website/match/MatchHero";
 import MatchScore from "@/components/website/match/MatchScore";
 import LinkedPlayers from "@/components/website/LinkedPlayers";
-import { cleanID, formatTime, getMatchContext, getScoreReportingBadge, url } from "@/utils/content-utils";
+import {
+    cleanID,
+    formatTime,
+    getMatchContext,
+    getReschedulingBadge, getScoreReportingBadge,
+    url
+} from "@/utils/content-utils";
 import { resizedImageNoWrap } from "@/utils/images";
 import { canEditMatch, isEventStaffOrHasRole } from "@/utils/client-action-permissions";
 import { useSettingsStore } from "@/stores/settingsStore";
@@ -121,6 +127,7 @@ export default {
                 event: ReactiveThing("event", {
                     theme: ReactiveThing("theme"),
                     player_relationships: ReactiveArray("player_relationships"),
+                    "staff": ReactiveArray("staff"),
                     broadcasts: ReactiveArray("broadcasts")
                 }),
                 casters: ReactiveArray("casters"),
@@ -220,8 +227,8 @@ export default {
 
             if (this.showHeadToHead) items.push("head-to-head");
             if (this.showEditor) items.push("editor");
-            if ((this.scoreReportingEnabled && !this.matchComplete) || (this.$route?.path?.endsWith("/score-reporting"))) items.push("score-reporting");
-            if ((this.reschedulingEnabled && !this.matchComplete) || (this.$route?.path?.endsWith("/rescheduling"))) items.push("rescheduling");
+            if ((this.scoreReportingEnabled) || (this.$route?.path?.endsWith("/score-reporting"))) items.push("score-reporting");
+            if ((this.reschedulingEnabled) || (this.$route?.path?.endsWith("/rescheduling"))) items.push("rescheduling");
 
             return items;
         },
@@ -244,54 +251,65 @@ export default {
                 ...team.owners || [],
             ].some(personID => cleanID(player?.id) === cleanID(personID)));
         },
-        existingScoreReport() {
-            return (ReactiveRoot(this.match?.id, {
-                "reports": ReactiveArray("reports", {
-                    "team": ReactiveThing("team"),
-                    "player": ReactiveThing("player")
-                })
-            })?.reports || []).find(report => report.type === "Scores" && cleanID(report.match?.[0]) === cleanID(this.match?.id));
-        },
-        reschedulingScoreReport() {
-            return (ReactiveRoot(this.match?.id, {
-                "reports": ReactiveArray("reports", {
-                    "team": ReactiveThing("team"),
-                    "player": ReactiveThing("player")
-                })
-            })?.reports || []).find(report => report.type === "Rescheduling" && !report.approved && cleanID(report.match?.[0]) === cleanID(this.match?.id));
-        },
         scoreReportingBadge() {
-            const { user } = useAuthStore();
-            const state = {
-                "reports_enabled": this.scoreReportingEnabled,
-                "existing_report": !!this.existingScoreReport?.id,
-                "is_on_teams": !!this.controllableTeams?.length,
-                "is_opponent": this.existingScoreReport?.team?.id ? this.controllableTeams.some(t => cleanID(t.id) !== cleanID(this.existingScoreReport?.team?.id)) : null,
-                "is_submitter": this.existingScoreReport?.team?.id ? this.controllableTeams.some(t => cleanID(t.id) === cleanID(this.existingScoreReport?.team?.id)) : null,
-                "is_staff": isEventStaffOrHasRole(user, { event: this.match?.event, websiteRoles: ["Can edit any match", "Can edit any event"] })
-            };
+            const { isAuthenticated, user } = useAuthStore();
+            if (!isAuthenticated) return null;
+            if (!(this.controllableTeams?.length || isEventStaffOrHasRole(user, { event: this.match?.event, websiteRoles: ["Can edit any match", "Can edit any event"] }))) return null;
 
-            return getScoreReportingBadge(state, this.existingScoreReport, this.eventSettings);
+            const reports = (ReactiveRoot(this.match?.id, {
+                "reports": ReactiveArray("reports", {
+                    "team": ReactiveThing("team"),
+                    "player": ReactiveThing("player")
+                })
+            })?.reports || []);
+
+            return getScoreReportingBadge(this.scoreReportState(reports, "Scores"), this.eventSettings);
         },
         reschedulingBadge() {
-            const { user } = useAuthStore();
-            const state = {
-                "reports_enabled": this.reschedulingEnabled,
-                "existing_report": !!this.reschedulingScoreReport?.id,
-                "is_on_teams": !!this.controllableTeams?.length,
-                "is_opponent": this.reschedulingScoreReport?.team?.id ? this.controllableTeams.some(t => cleanID(t.id) !== cleanID(this.reschedulingScoreReport?.team?.id)) : null,
-                "is_submitter": this.reschedulingScoreReport?.team?.id ? this.controllableTeams.some(t => cleanID(t.id) === cleanID(this.reschedulingScoreReport?.team?.id)) : null,
-                "is_staff": isEventStaffOrHasRole(user, { event: this.match?.event, websiteRoles: ["Can edit any match", "Can edit any event"] })
-            };
+            const { isAuthenticated, user } = useAuthStore();
+            if (!isAuthenticated) return null;
+            if (!(this.controllableTeams?.length || isEventStaffOrHasRole(user, { event: this.match?.event, websiteRoles: ["Can edit any match", "Can edit any event"] }))) return null;
 
-            return getScoreReportingBadge(state, this.reschedulingScoreReport, this.eventSettings, "rescheduling");
-        }
+            const reports = (ReactiveRoot(this.match?.id, {
+                "reports": ReactiveArray("reports", {
+                    "team": ReactiveThing("team"),
+                    "player": ReactiveThing("player")
+                })
+            })?.reports || []);
+            return getReschedulingBadge(this.scoreReportState(reports, "Rescheduling"), this.eventSettings);
+        },
     },
     methods: {
         subLink(subLinkURL) {
             return `/match/${this.match.id}/${subLinkURL}`;
         },
-        url
+        url,
+
+        scoreReportState(reports, type) {
+            const { isAuthenticated, user } = useAuthStore();
+            if (!isAuthenticated) return null;
+
+            const report = reports.find(report => report.type === type && cleanID(report.match?.[0]) === cleanID(this.match?.id));
+            let loading = false;
+            if (reports.some(r => r.__loading || !r.id)) loading = true;
+
+            console.log("score report state", report);
+            return {
+                report,
+                state: {
+                    "reports_enabled": this.scoreReportingEnabled,
+                    "has_existing_report": report?.id,
+                    "reports_loading": loading,
+                    "is_complete": this.match.first_to && [this.match.score_1, this.match.score_2].some(s => s === this.match.first_to),
+                    "is_on_teams": !!this.controllableTeams?.length,
+                    "is_opponent": report?.team?.id ? this.controllableTeams.some(t => cleanID(t.id) !== cleanID(report?.team?.id)) : null,
+                    "is_submitter": report?.team?.id ? this.controllableTeams.some(t => cleanID(t.id) === cleanID(report?.team?.id)) : null,
+                    "is_staff": isEventStaffOrHasRole(user, { event: this.match?.event, websiteRoles: ["Can edit any match", "Can edit any event"] }),
+                    "settings": this.eventSettings,
+                    "match_complete": [this.match.score_1 || 0, this.match.score_2 || 0].some(score => this.match.first_to === score)
+                }
+            };
+        },
     },
     watch: {
         eventID: {

--- a/website/src/views/sub-views/MatchRescheduling.vue
+++ b/website/src/views/sub-views/MatchRescheduling.vue
@@ -1,0 +1,720 @@
+<template>
+    <div class="match-rescheduling">
+        <h2 class="text-center">{{ reschedule.slice(0, -1) }}ing</h2>
+        <div v-if="reschedulingEnabled && reschedulingAvailable && !matchComplete" class="flex-center flex-column gap-4">
+            <div class="score-reporting-status d-flex flex-column gap-3">
+                <div v-for="step in steps" :key="step.number" class="step d-flex flex-center gap-3" :class="`status-${step.status}`">
+                    <div class="step-num fw-bold">{{ step.number }}</div>
+                    <div class="step-content flex-grow-1">
+                        <div class="step-title fw-bold">{{ step.title }}</div>
+                        <div class="step-description">{{ step.description }}</div>
+                    </div>
+                    <div class="step-icon-holder flex-center">
+                        <div class="step-icon">
+                            <i :class="`fa-fw ${step.icon}`"></i>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div v-if="currentAction" class="step-action action-container text-left opacity-changes" :class="{'low-opacity': processing}">
+                <div v-if="currentAction?.title?.text" class="action-title" :class="`bg-${currentAction?.title?.variant || 'dark'} fw-bold h5 mb-0`">
+                    {{ currentAction?.title?.text }}
+                    <transition name="fade">
+                        <div v-if="processing" key="spinner" class="title-spinner flex-center">
+                            <div>Working</div>
+                            <i class="fas fa-cog fa-spin fa-fw ml-1"></i>
+                        </div>
+                    </transition>
+                </div>
+                <div v-if="(currentAction?.content || [])?.length" class="action-content bg-dark gap-2">
+                    <div v-if="(currentAction?.content || [])?.includes('information')">
+                        <div><b>Earliest start:</b> {{ formatTime(match.earliest_start) }}</div>
+                        <div><b>Latest start:</b> {{ formatTime(match.latest_start) }}</div>
+                        <div v-if="match.start"><b>Current scheduled start:</b> {{ formatTime(match.start) }}</div>
+                        <div v-else>This match does not currently have a scheduled start time</div>
+                    </div>
+                    <div v-if="(currentAction?.content || [])?.includes('match start')" class="border border-success p-2 rounded px-3">
+                        <b>Match start time:</b> {{ formatTime(match.start || existingReportData?.start) }}
+                    </div>
+                    <div v-if="['datetimepicker', 'proposed-report', 'proposed-local'].some(text => (currentAction?.content || [])?.includes(text))" class="time-holder d-flex gap-2 flex-center">
+                        <div v-if="(currentAction?.content || [])?.includes('datetime picker')">
+                            <AdvancedDateEditor
+                                :saved-time="match?.start || match?.earliest_start"
+                                :earliest-time="match?.earliest_start"
+                                :latest-time="match?.latest_start"
+                                @submit="(timeString) => proposedTime = timeString">
+                                Choose time
+                            </AdvancedDateEditor>
+                        </div>
+                        <div v-if="(currentAction?.content || [])?.includes('proposed-report') && existingReportData?.start" class="border border-primary p-2 rounded px-3">
+                            <b>Proposed time:</b> {{ formatTime(existingReportData?.start) }}
+                        </div>
+                        <div v-else-if="(currentAction?.content || [])?.includes('proposed-local') && proposedTime" class="border border-primary p-2 rounded px-3">
+                            <b>Proposed time:</b> {{ formatTime(proposedTime) }}
+                        </div>
+                    </div>
+
+                    <div v-if="(currentAction?.content || [])?.includes('staff editor link')" class="d-flex flex-column align-items-start gap-1 mb-1">
+                        <div>You can't submit a {{ this.reschedule.toLowerCase() }} request, but you can edit the match directly:</div>
+                        <router-link class="btn btn-primary text-white" :to="url('match', match, { subPage: 'editor' })">Match editor</router-link>
+                    </div>
+                    <div v-if="(currentAction?.content || [])?.includes('log')">
+                        <div class="mb-1 fw-bold">Request log</div>
+                        <pre class="mb-1">{{ existingScoreReport.log }}</pre>
+                    </div>
+                </div>
+                <div v-if="currentAction?.footer?.length" class="action-footer action-footer-footers bg-dark flex-column gap-2">
+                    <div v-for="footer in currentAction.footer" :key="footer.heading" class="footer-item">
+                        <i v-if="footer.icon" class="fa-fw mr-1" :class="footer.icon"></i>
+                        <b v-if="footer.heading">{{ footer.heading }}</b>
+                        <br v-if="footer.heading && footer.description">
+                        <small v-if="footer.description">{{ footer.description }}</small>
+                    </div>
+                </div>
+                <div v-if="currentAction?.buttons?.length" class="action-footer action-footer-buttons bg-dark flex-column gap-2">
+                    <div>
+                        <b-button-group v-if="currentAction?.buttons?.length">
+                            <b-button
+                                v-for="button in currentAction.buttons"
+                                :key="button.reaction"
+                                :variant="button.style?.variant"
+                                :disabled="(button.disabled !== undefined ? button.disabled : null) || processing"
+                                class="opacity-changes"
+                                @click="button.click ? button.click(button) : actionButtonPress(button)">
+                                <i v-if="button.style?.icon" class="fa-fw mr-1" :class="button.style.icon"></i> {{ button.style?.text }}
+                            </b-button>
+                        </b-button-group>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div v-else-if="matchComplete" class="p-2 bg-dark text-center rounded">
+            This match is complete
+        </div>
+        <div v-else-if="!reschedulingAvailable" class="p-2 bg-dark text-center rounded">
+            Match {{ reschedule.slice(0,-1) }}ing is not set up for this match
+        </div>
+        <div v-else class="p-2 bg-dark text-center rounded">
+            Match {{ reschedule.slice(0,-1) }}ing is not enabled
+        </div>
+
+        <!--
+         TODO:
+            - Make sure Discord messages cover all events
+            - Investigate what should be done for persistent Discord messages (i.e. some denials won't trigger a message to be removed)
+            - Lockdown server logic for all events
+            - Update sidebar/schedule badge to match logic
+         -->
+
+        <!--        <pre class="mt-4 border border-primary p-2 rounded bg-dark"><b>Current action</b><br>{{ currentAction }}</pre>-->
+        <!--        <pre>{{ {...authStatus, isOpponent } }}</pre>-->
+    </div>
+</template>
+
+<script>
+import { ReactiveArray, ReactiveRoot, ReactiveThing } from "@/utils/reactive.js";
+import { cleanID, formatTime, url } from "@/utils/content-utils.js";
+import { useAuthStore } from "@/stores/authStore.ts";
+import { isEventStaffOrHasRole } from "@/utils/client-action-permissions.js";
+import AdvancedDateEditor from "@/components/website/dashboard/AdvancedDateEditor.vue";
+import { authenticatedRequest } from "@/utils/dashboard.ts";
+
+export default {
+    name: "MatchRescheduling",
+    components: { AdvancedDateEditor },
+    props: ["match"],
+    data: () => ({
+        proposedTime: null,
+        processing: false
+    }),
+    computed: {
+        eventSettings() {
+            if (!this.match?.event?.blocks) return null;
+            return JSON.parse(this.match.event.blocks);
+        },
+        /** @returns {Report | null} */
+        existingScoreReport() {
+            return (ReactiveRoot(this.match?.id, {
+                "reports": ReactiveArray("reports", {
+                    "team": ReactiveThing("team"),
+                    "player": ReactiveThing("player")
+                })
+            })?.reports || []).find(report => report.type === "Rescheduling" && cleanID(report.match?.[0]) === cleanID(this.match?.id));
+        },
+        existingReportData() {
+            if (!this.existingScoreReport?.data) return null;
+            try {
+                return JSON.parse(this.existingScoreReport.data);
+            } catch (e) {
+                console.error(e);
+                return null;
+            }
+        },
+        matchComplete() {
+            if (!this.match?.first_to) return false;
+            return [this.match?.score_1 || 0, this.match?.score_2 || 0].some(x => x === this.match?.first_to);
+        },
+        reschedulingEnabled() {
+            return this.eventSettings?.reporting?.rescheduling?.use;
+        },
+        reschedulingAvailable() {
+            return this.match?.earliest_start && this.match?.latest_start;
+        },
+        steps() {
+            const warningFooter = this.approvalWarning?.short ? [{ icon: "fas fa-exclamation-circle", heading: `This event requires ${this.approvalWarning.short} approval`, description: `The match will not be ${this.reschedule.toLowerCase()}d until ${this.approvalWarning.people} ${this.approvalWarning.types.length === 1 ? "has" : "have"} approved the request.` }] : [];
+            const steps = [
+                {
+                    key: "report",
+                    number: 1,
+                    title: "Score report",
+                    description: `Team submits ${this.reschedule.slice(0,-1)}ing request`,
+                    status: "inactive",
+                    icon: "fas fa-user-clock",
+                    actions: {
+                        submitter: {
+                            title: { text: `Submit a ${this.reschedule.toLowerCase()} request`, variant: "primary" },
+                            content: ["information", "datetime picker", "proposed-local", "proposed-report"],
+                            buttons: [{
+                                click: () => this.submitRequest(),
+                                disabled: !this.proposedTime || this.processing,
+                                style: {
+                                    variant: "success",
+                                    text: "Submit request",
+                                    icon: "fas fa-cloud-upload"
+                                },
+                                successToast: `${this.reschedule} request submitted`
+                            }],
+                            footer: warningFooter
+                        },
+                        staff: {
+                            title: {
+                                text: `No ${this.reschedule.toLowerCase()} request active`,
+                                variant: "secondary"
+                            },
+                            content: ["staff editor link"]
+                        },
+                    }
+                },
+            ];
+
+            if (this.existingScoreReport?.approved_by_team) {
+                steps[0].status = "complete";
+                steps[0].icon = "fas fa-check";
+                if (this.existingScoreReport?.player?.name && this.existingScoreReport?.team?.name) {
+                    steps[0].description = `${this.existingScoreReport?.player?.name} submitted request for ${this.existingScoreReport?.team?.name}`;
+                }
+            }
+
+            if (this.eventSettings?.reporting?.rescheduling?.opponentApprove) {
+                if (this.existingScoreReport?.denied_by_opponent) {
+                    steps.push({
+                        key: "opponentApprove",
+                        number: 2,
+                        title: "Opponent approval",
+                        description: `${this.opponentTeam?.name} denied the request`,
+                        status: "blocking",
+                        icon: "fas fa-user-times",
+                        actions: {
+                            teams: {
+                                title: { text: `${this.reschedule} request denied by opponent`, variant: "danger" },
+                                content: ["information", "proposed-report", "log"],
+                                buttons: [
+                                    {
+                                        reaction: "delete",
+                                        action: "approve-match-reschedule",
+                                        style: {
+                                            variant: "primary",
+                                            icon: "fas fa-redo",
+                                            text: "Start new request"
+                                        },
+                                        successToast: "Match cleared and ready for a new request"
+                                    },
+                                ]
+                            },
+                            staff: {
+                                title: { text: `${this.reschedule} request denied by opponent`, variant: "danger" },
+                                content: ["information", "proposed-report", "log"],
+                                buttons: [
+                                    {
+                                        reaction: "delete",
+                                        action: "staff-approve-match-reschedule",
+                                        style: {
+                                            variant: "primary",
+                                            icon: "fas fa-redo",
+                                            text: "Start new request"
+                                        },
+                                        successToast: "Match cleared and ready for a new request"
+                                    },
+                                ]
+                            },
+                        }
+                    });
+                } else {
+                    // normal
+                    const newStep = {
+                        key: "opponentApprove",
+                        number: 2,
+                        title: "Opponent approval",
+                        description: "Opposing team approves the request",
+                        status: "inactive",
+                        icon: "fas fa-calendar-check",
+                        actions: {
+                            submitter: {
+                                title: { text: `${this.reschedule} request in progress` },
+                                buttons: [
+                                    {
+                                        reaction: "cancel", action: "approve-match-reschedule", style: { variant: "danger", icon: "fas fa-trash", text: "Cancel request" }, successToast: `${this.reschedule} request cancelled`
+                                    }
+                                ],
+                                content: ["information", "proposed-report"],
+                                footer: [{ heading: "Waiting for an opponent's response", icon: "fas fa-clock" }, ...warningFooter].filter(Boolean)
+                            },
+                            opponent: {
+                                title: { text: `Match ${this.reschedule.toLowerCase()} request`, variant: "primary" },
+                                content: ["information", "proposed-report"],
+                                buttons: [
+                                    { reaction: "approve", action: "approve-match-reschedule", style: { variant: "success", icon: "fas fa-check", text: "Approve" }, successToast: `${this.reschedule} request approved` },
+                                    { reaction: "deny", action: "approve-match-reschedule", style: { variant: "danger", icon: "fas fa-times", text: "Deny" }, successToast: `${this.reschedule} request denied` },
+                                ],
+                                footer: this.eventSettings?.reporting?.rescheduling?.staffApprove ? [{ heading: "This event requires staff approval", description: `Once you approve this ${this.reschedule.toLowerCase()} request, the match will not be ${this.reschedule.toLowerCase()}d until a staff member has approved it.`, icon: "fas fa-exclamation-circle" }] : null
+                            },
+                            staff: (this.existingScoreReport?.approved_by_staff && !this.existingScoreReport?.denied_by_staff)
+                                ? {
+                                    title: {
+                                        text: `${this.reschedule} request pre-approved`,
+                                        variant: "success"
+                                    },
+                                    content: ["information", "proposed-report", "log"],
+                                    buttons: [
+                                        { reaction: "force-approve", action: "staff-approve-match-reschedule", style: { variant: "primary", icon: "fas fa-shield-check", text: "Force approve" }, successToast: `${this.reschedule} request force approved` },
+                                        ...this.eventSettings?.reporting?.rescheduling?.staffApprove ? [{
+                                            reaction: "pre-approve",
+                                            action: "staff-approve-match-reschedule",
+                                            disabled: true,
+                                            successToast: `${this.reschedule} request pre-approved`,
+                                            style: {
+                                                variant: "success",
+                                                icon: "fas fa-check",
+                                                text: "Pre-approve"
+                                            }
+                                        }] : [],
+                                        { reaction: "deny", action: "staff-approve-match-reschedule", style: { variant: "danger", icon: "fas fa-times", text: "Deny" }, successToast: `${this.reschedule} request denied & locked` },
+                                        // { reaction: "delete", action: "staff-approve-match-reschedule", style: { variant: "danger", icon: "fas fa-trash", text: "Delete" }, successToast: `${this.reschedule} request deleted` },
+                                    ],
+                                    footer: [{ heading: "Waiting for opponent approval", icon: "fas fa-clock" }]
+                                }
+                                : {
+                                    title: {
+                                        text: this.eventSettings?.reporting?.rescheduling?.staffApprove ? `Pre-approve match ${this.reschedule.toLowerCase()}` : `${this.reschedule} request waiting for opponent approval`
+                                    },
+                                    content: ["information", "proposed-report"],
+                                    buttons: [
+                                        { reaction: "force-approve", action: "staff-approve-match-reschedule", style: { variant: "primary", icon: "fas fa-shield-check", text: "Force approve" }, successToast: `${this.reschedule} request force approved` },
+                                        ...this.eventSettings?.reporting?.rescheduling?.staffApprove ? [{
+                                            reaction: "pre-approve",
+                                            action: "staff-approve-match-reschedule",
+                                            successToast: `${this.reschedule} request pre-approved`,
+                                            style: {
+                                                variant: "success",
+                                                icon: "fas fa-check",
+                                                text: "Pre-approve"
+                                            }
+                                        }] : [],
+                                        { reaction: "deny", action: "staff-approve-match-reschedule", style: { variant: "danger", icon: "fas fa-times", text: "Deny" }, successToast: `${this.reschedule} request denied & locked` },
+                                    ],
+                                    footer: this.eventSettings?.reporting?.rescheduling?.staffApprove ?
+                                        [{ heading: "This event requires staff approval", icon: "fas fa-exclamation-circle" }] :
+                                        [{ heading: "This event does not require staff approval", icon: "fas fa-check" }]
+                                },
+                        }
+                    };
+
+                    if (this.existingScoreReport?.approved_by_opponent) {
+                        newStep.status = "complete";
+                        newStep.icon = "fas fa-check";
+                        if (this.opponentTeam?.name) {
+                            newStep.description = `${this.opponentTeam.name} approved the request`;
+                        }
+                    }
+
+                    steps.push(newStep);
+                }
+            } else {
+                steps.push({
+                    key: "opponentApprove",
+                    number: 2,
+                    title: "Opponent approval",
+                    description: "Opponent approval not needed on this match",
+                    status: "disabled",
+                    icon: "fas fa-check"
+                });
+            }
+
+            if (this.eventSettings?.reporting?.rescheduling?.staffApprove) {
+                if (this.existingScoreReport?.denied_by_staff) {
+                    steps.push({
+                        key: "staffApprove",
+                        number: steps.length + 1,
+                        title: "Staff approval",
+                        description: "Staff member denied the request",
+                        status: "blocking",
+                        icon: "fas fa-user-times",
+
+                        actions: {
+                            teams: {
+                                title: { text: `${this.reschedule} request denied by staff`, variant: "danger" },
+                                content: ["information", "proposed-report", "log"],
+                                footer: [{ icon: "fas fa-exclamation-triangle", heading: `This match is blocked from ${this.reschedule.slice(0,-1).toLowerCase()}ing requests`, description: `Contact event staff to reopen ${this.reschedule.slice(0,-1).toLowerCase()}ing if required.` }]
+                            },
+                            staff: {
+                                title: { text: `${this.reschedule} request denied by staff`, variant: "danger" },
+                                content: ["information", "proposed-report", "log"],
+                                buttons: [
+                                    { reaction: "delete", action: "staff-approve-match-reschedule", style: { variant: "primary", icon: "fas fa-redo", text: "Start new request" }, successToast: "Match cleared and ready for a new request" },
+                                ],
+                                footer: [{ icon: "fas fa-lock", heading: `This match is blocked from ${this.reschedule.slice(0,-1).toLowerCase()}ing requests`, description: `Staff can reset this match to reopen ${this.reschedule.slice(0,-1).toLowerCase()}ing.` }]
+                            },
+                        }
+                    });
+                } else {
+                    const newStep = {
+                        key: "staffApprove",
+                        number: steps.length + 1,
+                        title: "Staff approval",
+                        description: "Staff member approves the request",
+                        status: "inactive",
+                        icon: "fas fa-business-time",
+
+                        actions: {
+                            teams: {
+                                title: { text: "Waiting for staff approval" },
+                                content: ["information", "proposed-report"],
+                                // buttons: [
+                                //     { reaction: "cancel", action: "approve-match-reschedule", style: { variant: "danger", icon: "fas fa-trash", text: "Cancel request" } },
+                                // ],
+                                footer: warningFooter
+                            },
+                            staff: {
+                                title: {
+                                    text: `Approve match ${this.reschedule.toLowerCase()}`,
+                                    variant: "primary"
+                                },
+                                content: ["information", "proposed-report"],
+                                buttons: [
+                                    // { reaction: "force-approve", action: "staff-approve-match-reschedule", style: { variant: "primary", icon: "fas fa-shield-check", text: "Force approve" } },
+                                    { reaction: "approve", action: "staff-approve-match-reschedule", style: { variant: "success", icon: "fas fa-check", text: "Approve" } },
+                                    { reaction: "deny", action: "staff-approve-match-reschedule", style: { variant: "danger", icon: "fas fa-times", text: "Deny" } },
+                                    // { reaction: "delete", action: "staff-approve-match-reschedule", style: { variant: "danger", icon: "fas fa-trash", text: "Delete" } },
+                                ]
+                            }
+                        }
+                    };
+
+                    if (this.existingScoreReport?.force_approved) {
+                        newStep.status = "complete";
+                        newStep.icon = "fas fa-shield-check";
+                        newStep.description = "Staff member force approved this request";
+                    } else if (this.existingScoreReport?.approved_by_staff) {
+                        newStep.status = "complete";
+                        newStep.icon = "fas fa-check";
+                    }
+                    steps.push(newStep);
+                }
+            } else {
+                steps.push({
+                    key: "staffApprove",
+                    number: steps.length + 1,
+                    title: "Staff approval",
+                    description: "Staff approval not needed on this match",
+                    status: "disabled",
+                    icon: "fas fa-check"
+                });
+            }
+
+            let firstAvailable = steps.findIndex(s => s.status === "inactive");
+            if (firstAvailable !== -1) {
+                steps[firstAvailable].status = "active";
+            }
+
+            console.log(steps);
+            return steps;
+        },
+        teams() {
+            return (ReactiveRoot(this.match?.id, {
+                "teams": ReactiveArray("teams", {
+                    "players": ReactiveArray("players"),
+                    "captains": ReactiveArray("captains"),
+                    "staff": ReactiveArray("staff"),
+                    "owners": ReactiveArray("owners")
+                })
+            }))?.teams || [];
+        },
+        isOpponent() {
+            // find controllable teams that is not the one that reported this
+            if (!this.existingScoreReport?.team?.id) return false;
+            return this.controllableTeams.some(t => cleanID(t.id) !== cleanID(this.existingScoreReport?.team?.id));
+        },
+        opponentTeam() {
+            return this.teams.find(t => cleanID(t.id) !== cleanID(this.existingScoreReport?.team?.id));
+        },
+        controllableTeams() {
+            const { isAuthenticated, player } = useAuthStore();
+            if (!isAuthenticated) return [];
+
+            return (this.teams || []).filter(team => [
+                ...team.players || [],
+                ...team.captains || [],
+                ...team.staff || [],
+                ...team.owners || [],
+            ].some(person => cleanID(player?.id) === cleanID(person?.id)));
+        },
+        authStatus() {
+            const { isAuthenticated, user } = useAuthStore();
+            if (!isAuthenticated) return false;
+
+            let status = {};
+
+            if (this.controllableTeams?.length) status.team = true;
+
+            const editorPerm = isEventStaffOrHasRole(user, { event: this.match?.event, websiteRoles: ["Can edit any match", "Can edit any event"] });
+            if (editorPerm) status.staff = true;
+            return status;
+        },
+        currentStep() {
+            let next = (this.steps || []).find(s => s.status === "blocking");
+            if (next) {
+                return next;
+            }
+            next = (this.steps || []).find(s => s.status === "active");
+            if (next) {
+                return next;
+            }
+            return {
+                key: "complete",
+                number: this.steps.length + 1,
+                actions: {
+                    teams: {
+                        title: {
+                            text: `Match ${this.reschedule.toLowerCase()}d`,
+                            variant: "success"
+                        },
+                        buttons: [
+                            {
+                                reaction: "delete",
+                                action: "approve-match-reschedule",
+                                style: {
+                                    variant: "primary",
+                                    icon: "fas fa-redo",
+                                    text: "Start new request"
+                                },
+                                successToast: "Match ready for a new request"
+                            },
+                        ],
+                        content: ["match start", "log"]
+                    },
+                    staff: {
+                        title: {
+                            text: `Match ${this.reschedule.toLowerCase()}d`,
+                            variant: "success"
+                        },
+                        content: ["match start", "log"],
+                        buttons: [
+                            {
+                                reaction: "delete",
+                                action: "staff-approve-match-reschedule",
+                                style: {
+                                    variant: "primary",
+                                    icon: "fas fa-redo",
+                                    text: "Start new request"
+                                },
+                                successToast: "Match ready for a new request"
+                            },
+                        ],
+                    }
+                }
+            };
+        },
+        currentAction() {
+            if (!this.currentStep) return null;
+            let action;
+            if (this.authStatus?.team && !this.isOpponent) {
+                action = this.currentStep?.actions?.submitter;
+            } else if (this.authStatus?.team && this.isOpponent) {
+                action = this.currentStep?.actions?.opponent;
+            }
+            if (!action && this.authStatus?.team && this.currentStep?.actions?.teams) {
+                action = this.currentStep?.actions?.teams;
+            }
+            if (!action && this.authStatus?.staff) {
+                action = this.currentStep?.actions?.staff;
+            }
+            return action;
+        },
+        approvalWarning() {
+            const types = {};
+            if (this.eventSettings?.reporting?.rescheduling?.opponentApprove) {
+                types.opponent = true;
+            }
+            if (this.eventSettings?.reporting?.rescheduling?.staffApprove) {
+                types.staff = true;
+            }
+            if (this.existingScoreReport?.approved_by_opponent) {
+                types.opponent = false;
+            }
+            if (this.existingScoreReport?.approved_by_staff) {
+                types.staff = false;
+            }
+
+            return {
+                short: types.opponent && types.staff ? "opponent and staff" : (types.opponent ? "opponent" : (types.staff ? "staff" : null)),
+                people: types.opponent && types.staff ? "an opponent and a staff member" : (types.opponent ? "an opponent" : (types.staff ? "a staff member" : null)),
+                types: Object.values(types)
+            };
+        },
+        reschedule() {
+            if (this.match?.id && !this.match?.start) return "Schedule";
+            return "Reschedule";
+        }
+    },
+    methods: {
+        url,
+        formatTime,
+        async submitRequest() {
+            try {
+                if (!this.proposedTime) {
+                    return this.$notyf.error("No time was proposed");
+                }
+                this.processing = true;
+                const response = await authenticatedRequest("actions/submit-match-reschedule", {
+                    matchID: this.match.id,
+                    startTime: this.proposedTime
+                });
+                // if (response.error) this.errorMessage = response.errorMessage;
+                console.log(response);
+                this.processing = false;
+
+                if (!response.error) {
+                    this.$notyf.success({
+                        message: `${this.reschedule} request submitted`,
+                        duration: 3000
+                    });
+                }
+            } finally {
+                this.processing = false;
+            }
+        },
+        async actionButtonPress(button) {
+            this.processing = true;
+            try {
+                const response = await authenticatedRequest(`actions/${button.action}`, {
+                    matchID: this.match.id,
+                    reaction: button.reaction
+                });
+
+                if (!response.error) {
+                    this.$notyf.success(`Success: ${button.successToast || button.style.text.toLowerCase()}`);
+                }
+
+            } finally {
+                this.processing = false;
+            }
+
+        }
+    }
+};
+</script>
+
+<style scoped>
+    .score-reporting-status {
+        max-width: min(500px, 75%)
+    }
+    .step-num {
+        font-size: 1.5em;
+        width: .75em;
+        text-align: center;
+    }
+    .step-icon {
+        font-size: 2em;
+    }
+    .step-icon-holder {
+        background-color: rgba(255,255,255,0.1);
+        width:  4em;
+        height: 4em;
+        border-radius: 50%;
+        flex-shrink: 0;
+    }
+
+    .step.status-active .step-icon-holder {
+        background-color: var(--primary);
+    }
+    .step.status-complete .step-icon-holder {
+        background-color: var(--green);
+    }
+    .step.status-denied .step-icon-holder,
+    .step.status-blocking .step-icon-holder {
+        background-color: var(--red);
+    }
+    .step.status-countered .step-icon-holder {
+        background-color: var(--yellow);
+        color: var(--dark);
+    }
+    .step.status-disabled {
+        opacity: 0.5;
+    }
+
+    .step .step-icon i {
+        transform: translateY(-0.1em)
+    }
+    .step-action {
+        display: flex;
+        flex-direction: column;
+        max-width: 100%;
+    }
+
+
+    .action-container {
+        border: 1px solid rgba(255,255,255,0.1);
+        border-radius: .5em;
+        width: 100%;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        overflow: hidden;
+    }
+    .action-title, .action-footer, .action-content {
+        display: flex;
+        padding: 0.5em 0.75em;
+        width: 100%;
+    }
+    .action-content {
+        display: flex;
+        justify-content: center;
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 1em;
+    }
+    .action-footer-buttons {
+        align-items: flex-end;
+    }
+    .action-title {
+        border-bottom: 1px solid rgba(255,255,255,0.1);
+        position: relative;
+    }
+    .action-footer {
+        border-top: 1px solid rgba(255,255,255,0.1);
+    }
+    .action-footer small {
+        padding: 0.25em 0;
+        line-height: 1.1;
+        display: block;
+    }
+    .title-spinner {
+        position: absolute;
+        top: 0;
+        right: 0;
+        height: 100%;
+        padding: 0 0.5em;
+        font-size: 0.8em;
+        font-weight: 400;
+    }
+</style>

--- a/website/src/views/sub-views/MatchRescheduling.vue
+++ b/website/src/views/sub-views/MatchRescheduling.vue
@@ -54,7 +54,7 @@
                     </div>
                     <div v-if="(currentAction?.content || [])?.includes('log')">
                         <div class="mb-1 fw-bold">Request log</div>
-                        <pre class="mb-1">{{ existingScoreReport.log }}</pre>
+                        <ReportLog v-if="existingScoreReport?.log" :log="existingScoreReport.log" />
                     </div>
                 </div>
                 <div v-if="currentAction?.footer?.length" class="action-footer action-footer-footers bg-dark flex-column gap-2">

--- a/website/src/views/sub-views/MatchScoreReporting.vue
+++ b/website/src/views/sub-views/MatchScoreReporting.vue
@@ -216,7 +216,7 @@
 
 import MatchEditor from "@/components/website/dashboard/MatchEditor.vue";
 import { useAuthStore } from "@/stores/authStore";
-import { canEditMatch, isEventStaffOrHasRole } from "@/utils/client-action-permissions";
+import { isEventStaffOrHasRole } from "@/utils/client-action-permissions";
 import { ReactiveArray, ReactiveRoot, ReactiveThing } from "@/utils/reactive";
 import { cleanID, url } from "@/utils/content-utils";
 import MatchExplainerList from "@/components/website/dashboard/MatchExplainerList.vue";

--- a/website/src/views/sub-views/MatchScoreReporting.vue
+++ b/website/src/views/sub-views/MatchScoreReporting.vue
@@ -94,7 +94,7 @@
                     </div>
                     <div v-if="(currentAction?.content || [])?.includes('log')">
                         <div class="mb-1 fw-bold">Request log</div>
-                        <pre class="mb-1">{{ existingScoreReport.log }}</pre>
+                        <ReportLog v-if="existingScoreReport?.log" :log="existingScoreReport.log" />
                     </div>
                 </div>
                 <div v-if="currentAction?.footer?.length" class="action-footer action-footer-footers bg-dark flex-column gap-2">

--- a/website/src/views/sub-views/MatchScoreReporting.vue
+++ b/website/src/views/sub-views/MatchScoreReporting.vue
@@ -1,213 +1,302 @@
 <template>
     <div class="match-score-reporting">
-        <h2 class="text-center">Score Reporting</h2>
+        <div v-if="scoreReportingEnabled" class="flex-center flex-column gap-4 score-reporting-container">
+            <ReportStepsTop :steps="steps" title="Score Reporting" />
+            <!--            <div class="score-reporting-status d-flex flex-column gap-3">-->
+            <!--                <div v-for="step in steps" :key="step.number" class="step d-flex flex-center gap-3" :class="`status-${step.status}`">-->
+            <!--                    <div class="step-num fw-bold">{{ step.number }}</div>-->
+            <!--                    <div class="step-content flex-grow-1">-->
+            <!--                        <div class="step-title fw-bold">{{ step.title }}</div>-->
+            <!--                        <div class="step-description">{{ step.description }}</div>-->
+            <!--                    </div>-->
+            <!--                    <div class="step-icon-holder flex-center">-->
+            <!--                        <div class="step-icon">-->
+            <!--                            <i :class="`fa-fw ${step.icon}`"></i>-->
+            <!--                        </div>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--            </div>-->
 
-        <div v-if="scoreReportingEnabled" class="flex-center flex-column gap-4">
-            <div class="score-reporting-status d-flex flex-column gap-3">
-                <div v-for="step in steps" :key="step.number" class="step d-flex flex-center gap-3" :class="`status-${step.status}`">
-                    <div class="step-num fw-bold">{{ step.number }}</div>
-                    <div class="step-content flex-grow-1">
-                        <div class="step-title fw-bold">{{ step.title }}</div>
-                        <div class="step-description">{{ step.description }}</div>
+
+            <div v-if="existingScoreReport?.approved" class="text-center rounded action-container flex-column bg-dark">
+                <div class="action-title h5 mb-0 fw-bold bg-success d-flex align-items-center">
+                    <i class="fas fa-check-circle fa-fw mr-1"></i>Score report approved
+                </div>
+                <div class="action-content text-left">
+                    <ReportLog v-if="existingScoreReport?.log" :log="existingScoreReport.log" />
+                </div>
+            </div>
+            <div v-else-if="currentAction" class="step-action action-container text-left opacity-changes" :class="{'low-opacity': processing}">
+                <div v-if="currentAction?.title?.text" class="action-title" :class="`bg-${currentAction?.title?.variant || 'dark'} fw-bold h5 mb-0`">
+                    {{ currentAction?.title?.text }}
+                    <transition name="fade">
+                        <div v-if="processing" key="spinner" class="title-spinner flex-center">
+                            <div>Working</div>
+                            <i class="fas fa-cog fa-spin fa-fw ml-1"></i>
+                        </div>
+                    </transition>
+                </div>
+                <div v-if="(currentAction?.content || [])?.length" class="action-content bg-dark gap-2">
+                    <div v-if="!denyEditor && ['match-editor'].some(text => (currentAction?.content || [])?.includes(text))" class="editor-holder d-flex gap-2 flex-center">
+                        <MatchEditor
+                            ref="main-editor"
+                            :ignore-remote-updates="true"
+                            :match="match"
+                            :score-reporting="true"
+                            :hide-match-extras="true"
+                            score-report-action="submit"
+                            :lock-controls="true"
+                            :show-hero-picks="eventSettings?.reporting?.score?.showHeroPicks"
+                            :show-hero-bans="eventSettings?.reporting?.score?.showHeroBans"
+                            :show-map-bans="eventSettings?.reporting?.score?.showMapBans"
+                            :show-score-report-forfeit="eventSettings?.reporting?.score?.allowForfeits"
+                        />
                     </div>
-                    <div class="step-icon-holder flex-center">
-                        <div class="step-icon">
-                            <i :class="`fa-fw ${step.icon}`"></i>
+                    <div v-if="!denyEditor && ['proposed-report', 'proposed-counter-report'].some(text => (currentAction?.content || [])?.includes(text))" class="editor-holder d-flex gap-2 flex-center w-100">
+                        <div v-if="(currentAction?.content || [])?.includes('proposed-report')" class="match-explainer">
+                            <div v-if="(currentAction?.content || [])?.includes('proposed-counter-report')" class="match-explainer-title p-1 w-100 text-center fw-bold">Original report</div>
+                            <MatchExplainerList
+                                class="bg-light text-dark-low p-3 rounded"
+                                :edited-map-data="existingReportData?.mapData"
+                                :edited-match-data="existingReportData?.matchData"
+                                :match="match" />
+                        </div>
+                        <div v-if="(currentAction?.content || [])?.includes('proposed-counter-report')" class="match-explainer">
+                            <div class="match-explainer-title p-1 w-100 text-center fw-bold">Counter report</div>
+                            <MatchExplainerList
+                                class="bg-light text-dark-low p-3 rounded"
+                                :edited-map-data="existingReportCounterData?.mapData"
+                                :edited-match-data="existingReportCounterData?.matchData"
+                                :match="match" />
                         </div>
                     </div>
-                </div>
-            </div>
-
-
-            <div v-if="existingScoreReport?.approved" class="p-2 bg-success text-center rounded">
-                This match's score has been approved
-            </div>
-            <div v-else-if="currentStep?.key === 'report' && authStatus?.team" class="step-action">
-                <div class="p-2 bg-primary text-center rounded">
-                    Submit score report
-                </div>
-                <MatchEditor
-                    :ignore-remote-updates="true"
-                    :match="match"
-                    :score-reporting="true"
-                    :hide-match-extras="true"
-                    score-report-action="submit"
-                    :lock-controls="true"
-                    :show-hero-picks="eventSettings?.reporting?.score?.showHeroPicks"
-                    :show-hero-bans="eventSettings?.reporting?.score?.showHeroBans"
-                    :show-map-bans="eventSettings?.reporting?.score?.showMapBans"
-                    :show-score-report-forfeit="eventSettings?.reporting?.score?.allowForfeits"
-                />
-            </div>
-            <div v-else-if="currentStep?.key === 'opponentApprove' && denyEditor" class="step-action">
-                <div class="d-flex gap-2">
-                    <div class="p-2 bg-primary text-center rounded flex-grow-1">
-                        Denying score report: Submit your own score report
-                    </div>
-                    <b-button variant="danger" @click="denyEditor = false">
-                        <i class="fas fa-fw fa-times"></i> Cancel
-                    </b-button>
-                </div>
-                <MatchEditor
-                    :match="match"
-                    :ignore-remote-updates="true"
-                    :score-reporting="true"
-                    :hide-match-extras="true"
-                    score-report-action="counter"
-                    :proposed-data="existingReportData"
-                    :lock-controls="true"
-                    :show-hero-picks="eventSettings?.reporting?.score?.showHeroPicks"
-                    :show-hero-bans="eventSettings?.reporting?.score?.showHeroBans"
-                    :show-map-bans="eventSettings?.reporting?.score?.showMapBans"
-                    :show-score-report-forfeit="eventSettings?.reporting?.score?.allowForfeits"
-                />
-            </div>
-            <div v-else-if="currentStep?.key === 'opponentApprove'" class="step-action">
-                <div v-if="isOpponent" class="d-flex flex-column gap-2">
-                    <div class="p-2 bg-primary text-center rounded">
-                        Approve or deny {{ existingScoreReport?.team?.name ? existingScoreReport.team.name + "'s" : "your opponent's" }} score report.
+                    <div v-if="denyEditor && ['deny-editor'].some(text => (currentAction?.content || [])?.includes(text))" class="editor-holder d-flex gap-2 flex-center flex-column">
+                        <MatchEditor
+                            ref="deny-editor"
+                            :match="match"
+                            :ignore-remote-updates="true"
+                            :score-reporting="true"
+                            :hide-match-extras="true"
+                            score-report-action="counter"
+                            :proposed-data="existingReportData"
+                            :lock-controls="true"
+                            :show-hero-picks="eventSettings?.reporting?.score?.showHeroPicks"
+                            :show-hero-bans="eventSettings?.reporting?.score?.showHeroBans"
+                            :show-map-bans="eventSettings?.reporting?.score?.showMapBans"
+                            :show-score-report-forfeit="eventSettings?.reporting?.score?.allowForfeits"
+                        />
                     </div>
 
-                    <MatchExplainerList class="bg-light text-dark-low p-3 rounded" :edited-map-data="existingReportData?.mapData" :edited-match-data="existingReportData?.matchData" :match="match" />
 
-                    <div class="flex-center">
-                        <b-button-group>
-                            <b-button :disabled="processing.approval" variant="success" @click="approveReport('approve')"><i class="fas fa-fw fa-check mr-1"></i> Approve</b-button>
-                            <b-button :disabled="processing.approval" variant="danger" @click="denyEditor = true"><i class="fas fa-fw fa-times mr-1"></i> Deny & counter</b-button>
-                        </b-button-group>
+                    <div v-if="(currentAction?.content || [])?.includes('staff editor link')" class="d-flex flex-column align-items-start gap-1 mb-1">
+                        <div>You can't submit a score report, but you can edit the match directly:</div>
+                        <router-link class="btn btn-primary text-white" :to="url('match', match, { subPage: 'editor' })">Match editor</router-link>
+                    </div>
+                    <div v-if="(currentAction?.content || [])?.includes('log')">
+                        <div class="mb-1 fw-bold">Request log</div>
+                        <pre class="mb-1">{{ existingScoreReport.log }}</pre>
                     </div>
                 </div>
-                <div v-else-if="authStatus?.staff && !existingScoreReport?.approved_by_staff" class="d-flex flex-column gap-2">
-                    <div class="p-2 bg-primary text-center rounded">
-                        Pre-approve or deny {{ existingScoreReport.team.name }}'s score report.
-                    </div>
-
-                    <MatchExplainerList class="bg-light text-dark-low p-3 rounded" :edited-map-data="existingReportData?.mapData" :edited-match-data="existingReportData?.matchData" :match="match" />
-
-                    <div class="flex-center">
-                        <b-button-group>
-                            <b-button v-b-tooltip="'Approve without waiting for opponent approval'" :disabled="processing.approval" variant="primary" @click="staffApproveReport('force-approve')"><i class="fas fa-fw fa-shield-check mr-1"></i> Force approve</b-button>
-                            <b-button v-b-tooltip="'Auto approve this report once the opponent approves'" :disabled="processing.approval" variant="success" @click="staffApproveReport('pre-approve')"><i class="fas fa-fw fa-check mr-1"></i> Pre-approve</b-button>
-                            <b-button :disabled="processing.approval" variant="danger" @click="staffApproveReport('delete')"><i class="fas fa-fw fa-trash mr-1"></i> Deny & delete</b-button>
-                        </b-button-group>
+                <div v-if="currentAction?.footer?.length" class="action-footer action-footer-footers bg-dark flex-column gap-2">
+                    <div v-for="footer in currentAction.footer" :key="footer.heading" class="footer-item">
+                        <i v-if="footer.icon" class="fa-fw mr-1" :class="footer.icon"></i>
+                        <b v-if="footer.heading">{{ footer.heading }}</b>
+                        <br v-if="footer.heading && footer.description">
+                        <small v-if="footer.description">{{ footer.description }}</small>
                     </div>
                 </div>
-                <div v-else class="p-2 bg-dark text-center rounded">
-                    Waiting for opponent approval
-                </div>
-            </div>
-            <div v-else-if="currentStep?.key === 'staffApprove' && (authStatus?.staff || authStatus?.team)" class="step-action">
-                <div v-if="authStatus?.staff" class="d-flex flex-column gap-2">
-                    <div class="p-2 bg-primary text-center rounded">
-                        Approve or deny {{ existingScoreReport.team.name }}'s score report.
-                    </div>
-
-                    <MatchExplainerList class="bg-light text-dark-low p-3 rounded" :edited-map-data="existingReportData?.mapData" :edited-match-data="existingReportData?.matchData" :match="match" />
-
-                    <div class="flex-center">
-                        <b-button-group>
-                            <b-button :disabled="processing.approval" variant="success" @click="staffApproveReport('approve')"><i class="fas fa-fw fa-check mr-1"></i> Approve</b-button>
-                            <b-button :disabled="processing.approval" variant="danger" @click="staffApproveReport('delete')"><i class="fas fa-fw fa-trash mr-1"></i> Deny & delete</b-button>
-                        </b-button-group>
-                    </div>
-                </div>
-                <div v-else>
-                    Team - wait for staff approval
-                </div>
-            </div>
-            <div v-else-if="(matchComplete) || existingScoreReport?.approved" class="p-2 bg-success text-center rounded">
-                This match's score has been approved
-            </div>
-            <div v-else-if="currentStep?.key === 'counterReportApprove' && authStatus?.team">
-                <div v-if="isOpponent" class="d-flex flex-column gap-2">
-                    Counter approval submitted - wait for opponent approval.
-                </div>
-                <div v-else class="d-flex flex-column gap-2">
-                    <div class="p-2 bg-primary text-center rounded">
-                        Approve or deny counter score report.
-                    </div>
-
-                    <MatchExplainerList class="bg-light text-dark-low p-3 rounded" :edited-map-data="existingReportCounterData?.mapData" :edited-match-data="existingReportCounterData?.matchData" :match="match" />
-
-                    <div class="flex-center">
-                        <b-button-group>
-                            <b-button :disabled="processing.approval" variant="success" @click="approveReport('counter-approve')"><i class="fas fa-fw fa-check mr-1"></i> Approve</b-button>
-                            <b-button :disabled="processing.approval" variant="danger" @click="approveReport('counter-deny')"><i class="fas fa-fw fa-times mr-1"></i> Deny</b-button>
-                        </b-button-group>
-                    </div>
-                </div>
-            </div>
-            <div v-else-if="currentStep?.key === 'counterReportApprove' && authStatus?.staff" class="d-flex flex-column gap-2">
-                <div class="lists d-flex gap-2">
-                    <div class="d-flex flex-column gap-2">
-                        <div class="text-center fw-bold">Original report</div>
-                        <MatchExplainerList
-                            class="bg-light text-dark-low p-3 rounded"
-                            :edited-map-data="existingReportData?.mapData"
-                            :edited-match-data="existingReportCounterData?.matchData"
-                            :match="match" />
-                    </div>
-                    <div class="d-flex flex-column gap-2">
-                        <div class="text-center fw-bold">Countered report</div>
-                        <MatchExplainerList
-                            class="bg-light text-dark-low p-3 rounded"
-                            :edited-map-data="existingReportCounterData?.mapData"
-                            :edited-match-data="existingReportCounterData?.matchData"
-                            :match="match" />
-                    </div>
-                </div>
-
-                <div v-if="existingScoreReport?.approved_by_staff" class="p-2 bg-success text-center rounded">
-                    Approved by staff
-                </div>
-                <div>
-                    <div class="flex-center">
-                        <b-button-group class="flex-wrap">
+                <div v-if="currentAction?.buttons?.length" class="action-footer action-footer-buttons bg-dark flex-column gap-2">
+                    <div>
+                        <b-button-group v-if="currentAction?.buttons?.length">
                             <b-button
-                                v-b-tooltip="'Approve the original report without waiting for opponent approval'"
-                                :disabled="processing.approval"
-                                variant="primary"
-                                @click="staffApproveReport('force-approve')">
-                                <i class="fas fa-fw fa-shield-check mr-1"></i> Force approve original
-                            </b-button>
-                            <b-button
-                                v-if="!existingScoreReport?.approved_by_staff"
-                                v-b-tooltip="'Auto approve this report once both teams agree'"
-                                :disabled="processing.approval"
-                                variant="success"
-                                @click="staffApproveReport('pre-approve')">
-                                <i class="fas fa-fw fa-check mr-1"></i> Pre-approve
-                            </b-button>
-                            <b-button
-                                :disabled="processing.approval"
-                                variant="danger"
-                                @click="staffApproveReport('delete')">
-                                <i class="fas fa-fw fa-trash mr-1"></i> Deny
-                                & delete
-                            </b-button>
-                            <b-button
-                                v-b-tooltip="'Approve the countered report without waiting for opponent approval'"
-                                :disabled="processing.approval"
-                                variant="primary"
-                                @click="staffApproveReport('force-counter-approve')">
-                                <i class="fas fa-fw fa-shield-check mr-1"></i> Force approve counter
+                                v-for="button in currentAction.buttons"
+                                :key="button.reaction"
+                                v-b-tooltip
+                                :variant="button.style?.variant"
+                                :disabled="(button.disabled !== undefined ? button.disabled : null) || processing"
+                                :title="button.tooltip"
+                                class="opacity-changes"
+                                @click="button.click ? button.click(button) : actionButtonPress(button)">
+                                <i v-if="button.style?.icon" class="fa-fw mr-1" :class="button.style.icon"></i> {{ button.style?.text }}
                             </b-button>
                         </b-button-group>
                     </div>
                 </div>
             </div>
-            <div v-else-if="authStatus?.staff" class="p-2 bg-dark text-center rounded">
-                <div class="mb-2">You can't submit a score report, but you can edit the match directly</div>
-                <router-link class="btn btn-primary text-white" :to="url('match', match, { subPage: 'editor' })">Match editor</router-link>
+            <!--            <div v-else-if="currentStep?.key === 'report' && authStatus?.team" class="step-action action-container">-->
+            <!--                <div class="action-title bg-primary fw-bold h5 mb-0">-->
+            <!--                    Submit score report-->
+            <!--                    <transition name="fade">-->
+            <!--                        <div v-if="processing" key="spinner" class="title-spinner flex-center">-->
+            <!--                            <div>Working</div>-->
+            <!--                            <i class="fas fa-cog fa-spin fa-fw ml-1"></i>-->
+            <!--                        </div>-->
+            <!--                    </transition>-->
+            <!--                </div>-->
+            <!--            </div>-->
+            <!--            <div v-else-if="currentStep?.key === 'opponentApprove' && denyEditor" class="step-action">-->
+            <!--                <div class="d-flex gap-2">-->
+            <!--                    <div class="p-2 bg-primary text-center rounded flex-grow-1">-->
+            <!--                        Denying score report: Submit your own score report-->
+            <!--                    </div>-->
+            <!--                    <b-button variant="danger" @click="denyEditor = false">-->
+            <!--                        <i class="fas fa-fw fa-times"></i> Cancel-->
+            <!--                    </b-button>-->
+            <!--                </div>-->
+            <!--            </div>-->
+            <!--            <div v-else-if="currentStep?.key === 'opponentApprove'" class="step-action action-container">-->
+            <!--                <div v-if="isOpponent" class="d-flex flex-column gap-2">-->
+            <!--                    <div class="p-2 bg-primary text-center rounded">-->
+            <!--                        Approve or deny {{ existingScoreReport?.team?.name ? existingScoreReport.team.name + "'s" : "your opponent's" }} score report.-->
+            <!--                    </div>-->
+
+            <!--                    <MatchExplainerList class="bg-light text-dark-low p-3 rounded" :edited-map-data="existingReportData?.mapData" :edited-match-data="existingReportData?.matchData" :match="match" />-->
+
+            <!--                    <div class="flex-center">-->
+            <!--                        <b-button-group>-->
+            <!--                            <b-button :disabled="processing" variant="success" @click="approveReport('approve')"><i class="fas fa-fw fa-check mr-1"></i> Approve</b-button>-->
+            <!--                            <b-button :disabled="processing" variant="danger" @click="denyEditor = true"><i class="fas fa-fw fa-times mr-1"></i> Deny & counter</b-button>-->
+            <!--                        </b-button-group>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--                <div v-else-if="authStatus?.staff && !existingScoreReport?.approved_by_staff" class="d-flex flex-column gap-2">-->
+            <!--                    <div class="p-2 bg-primary text-center rounded">-->
+            <!--                        Pre-approve or deny {{ existingScoreReport.team.name }}'s score report.-->
+            <!--                    </div>-->
+
+            <!--                    <MatchExplainerList class="bg-light text-dark-low p-3 rounded" :edited-map-data="existingReportData?.mapData" :edited-match-data="existingReportData?.matchData" :match="match" />-->
+
+            <!--                    <div class="flex-center">-->
+            <!--                        <b-button-group>-->
+            <!--                            <b-button v-b-tooltip="'Approve without waiting for opponent approval'" :disabled="processing" variant="primary" @click="staffApproveReport('force-approve')"><i class="fas fa-fw fa-shield-check mr-1"></i> Force approve</b-button>-->
+            <!--                            <b-button v-b-tooltip="'Auto approve this report once the opponent approves'" :disabled="processing" variant="success" @click="staffApproveReport('pre-approve')"><i class="fas fa-fw fa-check mr-1"></i> Pre-approve</b-button>-->
+            <!--                            <b-button :disabled="processing" variant="danger" @click="staffApproveReport('delete')"><i class="fas fa-fw fa-trash mr-1"></i> Deny & delete</b-button>-->
+            <!--                        </b-button-group>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--                <div v-else class="action-title bg-dark fw-bold h5 mb-0 border-0">-->
+            <!--                    Waiting for opponent approval-->
+            <!--                </div>-->
+            <!--            </div>-->
+            <!--            <div v-else-if="currentStep?.key === 'staffApprove' && (authStatus?.staff || authStatus?.team)" class="step-action">-->
+            <!--                <div v-if="authStatus?.staff" class="d-flex flex-column gap-2">-->
+            <!--                    <div class="p-2 bg-primary text-center rounded">-->
+            <!--                        Approve or deny {{ existingScoreReport.team.name }}'s score report.-->
+            <!--                    </div>-->
+
+            <!--                    <MatchExplainerList class="bg-light text-dark-low p-3 rounded" :edited-map-data="existingReportData?.mapData" :edited-match-data="existingReportData?.matchData" :match="match" />-->
+
+            <!--                    <div class="flex-center">-->
+            <!--                        <b-button-group>-->
+            <!--                            <b-button :disabled="processing" variant="success" @click="staffApproveReport('approve')"><i class="fas fa-fw fa-check mr-1"></i> Approve</b-button>-->
+            <!--                            <b-button :disabled="processing" variant="danger" @click="staffApproveReport('delete')"><i class="fas fa-fw fa-trash mr-1"></i> Deny & delete</b-button>-->
+            <!--                        </b-button-group>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--                <div v-else>-->
+            <!--                    Team - wait for staff approval-->
+            <!--                </div>-->
+            <!--            </div>-->
+            <!--            <div v-else-if="(matchComplete) || existingScoreReport?.approved" class="p-2 bg-success text-center rounded">-->
+            <!--                This match's score has been approved-->
+            <!--            </div>-->
+            <!--            <div v-else-if="currentStep?.key === 'counterReportApprove' && authStatus?.team">-->
+            <!--                <div v-if="isOpponent" class="d-flex flex-column gap-2">-->
+            <!--                    Counter approval submitted - wait for opponent approval.-->
+            <!--                </div>-->
+            <!--                <div v-else class="d-flex flex-column gap-2">-->
+            <!--                    <div class="p-2 bg-primary text-center rounded">-->
+            <!--                        Approve or deny counter score report.-->
+            <!--                    </div>-->
+
+            <!--                    <MatchExplainerList class="bg-light text-dark-low p-3 rounded" :edited-map-data="existingReportCounterData?.mapData" :edited-match-data="existingReportCounterData?.matchData" :match="match" />-->
+
+            <!--                    <div class="flex-center">-->
+            <!--                        <b-button-group>-->
+            <!--                            <b-button :disabled="processing" variant="success" @click="approveReport('counter-approve')"><i class="fas fa-fw fa-check mr-1"></i> Approve</b-button>-->
+            <!--                            <b-button :disabled="processing" variant="danger" @click="approveReport('counter-deny')"><i class="fas fa-fw fa-times mr-1"></i> Deny</b-button>-->
+            <!--                        </b-button-group>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--            </div>-->
+            <!--            <div v-else-if="currentStep?.key === 'counterReportApprove' && authStatus?.staff" class="d-flex flex-column gap-2">-->
+            <!--                <div class="lists d-flex gap-2">-->
+            <!--                    <div class="d-flex flex-column gap-2">-->
+            <!--                        <div class="text-center fw-bold">Original report</div>-->
+            <!--                        <MatchExplainerList-->
+            <!--                            class="bg-light text-dark-low p-3 rounded"-->
+            <!--                            :edited-map-data="existingReportData?.mapData"-->
+            <!--                            :edited-match-data="existingReportCounterData?.matchData"-->
+            <!--                            :match="match" />-->
+            <!--                    </div>-->
+            <!--                    <div class="d-flex flex-column gap-2">-->
+            <!--                        <div class="text-center fw-bold">Countered report</div>-->
+            <!--                        <MatchExplainerList-->
+            <!--                            class="bg-light text-dark-low p-3 rounded"-->
+            <!--                            :edited-map-data="existingReportCounterData?.mapData"-->
+            <!--                            :edited-match-data="existingReportCounterData?.matchData"-->
+            <!--                            :match="match" />-->
+            <!--                    </div>-->
+            <!--                </div>-->
+
+            <!--                <div v-if="existingScoreReport?.approved_by_staff" class="p-2 bg-success text-center rounded">-->
+            <!--                    Approved by staff-->
+            <!--                </div>-->
+            <!--                <div>-->
+            <!--                    <div class="flex-center">-->
+            <!--                        <b-button-group class="flex-wrap">-->
+            <!--                            <b-button-->
+            <!--                                v-b-tooltip="'Approve the original report without waiting for opponent approval'"-->
+            <!--                                :disabled="processing"-->
+            <!--                                variant="primary"-->
+            <!--                                @click="staffApproveReport('force-approve')">-->
+            <!--                                <i class="fas fa-fw fa-shield-check mr-1"></i> Force approve original-->
+            <!--                            </b-button>-->
+            <!--                            <b-button-->
+            <!--                                v-if="!existingScoreReport?.approved_by_staff"-->
+            <!--                                v-b-tooltip="'Auto approve this report once both teams agree'"-->
+            <!--                                :disabled="processing"-->
+            <!--                                variant="success"-->
+            <!--                                @click="staffApproveReport('pre-approve')">-->
+            <!--                                <i class="fas fa-fw fa-check mr-1"></i> Pre-approve-->
+            <!--                            </b-button>-->
+            <!--                            <b-button-->
+            <!--                                :disabled="processing"-->
+            <!--                                variant="danger"-->
+            <!--                                @click="staffApproveReport('delete')">-->
+            <!--                                <i class="fas fa-fw fa-trash mr-1"></i> Deny-->
+            <!--                                & delete-->
+            <!--                            </b-button>-->
+            <!--                            <b-button-->
+            <!--                                v-b-tooltip="'Approve the countered report without waiting for opponent approval'"-->
+            <!--                                :disabled="processing"-->
+            <!--                                variant="primary"-->
+            <!--                                @click="staffApproveReport('force-counter-approve')">-->
+            <!--                                <i class="fas fa-fw fa-shield-check mr-1"></i> Force approve counter-->
+            <!--                            </b-button>-->
+            <!--                        </b-button-group>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--            </div>-->
+            <div v-else-if="authStatus?.staff || authStatus?.team" class="text-center rounded action-container flex-column bg-dark">
+                <div class="action-title h5 mb-0 fw-bold bg-dark d-flex align-items-center">
+                    <i class="fas fa-stopwatch fa-fw mr-1"></i>No action available at this time
+                </div>
+                <div class="action-content text-left">
+                    <ReportLog v-if="existingScoreReport?.log" :log="existingScoreReport.log" />
+                </div>
             </div>
-            <div v-else class="p-2 bg-dark text-center rounded">
-                You don't have access to report scores for this match
+            <div v-else class="p-2 bg-dark text-center rounded action-container h5 mb-0 fw-bold">
+                <i class="fas fa-ban fa-fw mr-1"></i>You don't have access to report scores for this match
             </div>
 
-            <pre v-if="existingScoreReport?.log" style="white-space: pre-wrap">{{ existingScoreReport.log }}</pre>
+            <!--            <pre style="white-space: pre-wrap;width:100%;">currentAction:<br>{{ currentAction || typeof (currentAction) }}</pre>-->
+            <!--            <pre style="white-space: pre-wrap;width:100%;">currentStep:<br>{{ currentStep }}</pre>-->
+
+            <!--            <pre v-if="existingScoreReport?.log" style="white-space: pre-wrap">{{ existingScoreReport.log }}</pre>-->
         </div>
-        <div v-else class="p-2 bg-dark text-center rounded">
-            Team score reporting is not enabled
+        <div v-else class="p-2 bg-dark text-center rounded action-container h5 mb-0 fw-bold">
+            <i class="fas fa-ban fa-fw mr-1"></i>Score reporting is not enabled
         </div>
     </div>
 </template>
@@ -221,6 +310,8 @@ import { ReactiveArray, ReactiveRoot, ReactiveThing } from "@/utils/reactive";
 import { cleanID, url } from "@/utils/content-utils";
 import MatchExplainerList from "@/components/website/dashboard/MatchExplainerList.vue";
 import { authenticatedRequest } from "@/utils/dashboard.ts";
+import ReportStepsTop from "@/components/website/ReportStepsTop.vue";
+import ReportLog from "@/components/website/ReportLog.vue";
 
 /**
  * @typedef {object} Report
@@ -238,10 +329,10 @@ import { authenticatedRequest } from "@/utils/dashboard.ts";
 
 export default {
     name: "MatchScoreReporting",
-    components: { MatchExplainerList, MatchEditor },
+    components: { ReportLog, ReportStepsTop, MatchExplainerList, MatchEditor },
     props: ["match"],
     data: () => ({
-        processing: {},
+        processing: false,
         denyEditor: false
     }),
     computed: {
@@ -299,7 +390,7 @@ export default {
             return this.controllableTeams.some(t => cleanID(t.id) !== cleanID(this.existingScoreReport?.team?.id));
         },
         opponentTeam() {
-            return this.controllableTeams.find(t => cleanID(t.id) !== cleanID(this.existingScoreReport?.team?.id));
+            return this.teams.find(t => cleanID(t.id) !== cleanID(this.existingScoreReport?.team?.id));
         },
         controllableTeams() {
             const { isAuthenticated, player } = useAuthStore();
@@ -324,7 +415,52 @@ export default {
             if (editorPerm) status.staff = true;
             return status;
         },
+        currentAction() {
+            if (!this.currentStep) return null;
+            let action;
+            if (this.authStatus?.team && !this.isOpponent) {
+                action = this.currentStep?.actions?.submitter;
+            } else if (this.authStatus?.team && this.isOpponent) {
+                action = this.currentStep?.actions?.opponent;
+            }
+            if (!action && this.authStatus?.team && this.currentStep?.actions?.teams) {
+                action = this.currentStep?.actions?.teams;
+            }
+            if (!action && this.authStatus?.staff) {
+                action = this.currentStep?.actions?.staff;
+            }
+            return action;
+        },
+        approvalWarning() {
+            const types = {};
+            if (this.eventSettings?.reporting?.score?.opponentApprove) {
+                types.opponent = true;
+            }
+            if (this.eventSettings?.reporting?.score?.staffApprove) {
+                types.staff = true;
+            }
+            if (this.existingScoreReport?.approved_by_opponent || this.existingScoreReport?.countered_by_opponent) {
+                types.opponent = false;
+            }
+            if (this.existingScoreReport?.approved_by_staff) {
+                types.staff = false;
+            }
+            return {
+                short: types.opponent && types.staff ? "opponent and staff" : (types.opponent ? "opponent" : (types.staff ? "staff" : null)),
+                people: types.opponent && types.staff ? "an opponent and a staff member" : (types.opponent ? "an opponent" : (types.staff ? "a staff member" : null)),
+                types: Object.entries(types).filter(([key, active]) => active).map(([key]) => key)
+            };
+        },
         steps() {
+            const warningFooter = this.approvalWarning?.short ? [{
+                icon: "fas fa-exclamation-circle",
+                heading: `This event requires ${this.approvalWarning.short} approval`,
+                description: `The score report will not be confirmed until ${this.approvalWarning.people} ${this.approvalWarning.types.length === 1 ? "has" : "have"} approved the request.`
+            }] : (this.needsNoApproval ? [{
+                icon: "fas fa-check",
+                heading: "This event does not require any approval for score reporting",
+            }] : []);
+
             const steps = [
                 {
                     key: "report",
@@ -332,7 +468,27 @@ export default {
                     title: "Score report",
                     description: "Team submits the maps and scores of the match",
                     status: "inactive",
-                    icon: "fas fa-clipboard-list"
+                    icon: "fas fa-clipboard-list",
+                    actions: {
+                        submitter: {
+                            title: {
+                                text: "Submit a score report",
+                                variant: "primary"
+                            },
+                            content: ["match-editor"],
+                            footer: warningFooter,
+                            buttons: [
+                                { click: () => { this.$refs["main-editor"].scoreReportConfirmModal = true; }, style: { variant: "success", icon: "fas fa-cloud-upload", text: "Submit report" } },
+                            ]
+                        },
+                        staff: {
+                            title: {
+                                text: "No score reported",
+                                variant: "secondary"
+                            },
+                            content: ["staff editor link"]
+                        },
+                    }
                 },
             ];
 
@@ -351,7 +507,109 @@ export default {
                     title: "Opponent approval",
                     description: "Opposing team approves the report",
                     status: "inactive",
-                    icon: "fas fa-clipboard-list-check"
+                    icon: "fas fa-clipboard-list-check",
+                    actions: {
+                        submitter: {
+                            title: { text: "Score report submitted" },
+                            content: ["proposed-report"],
+                            footer: [{ heading: "Waiting for an opponent's response", icon: "fas fa-clock" }, ...warningFooter].filter(Boolean)
+                        },
+                        opponent: {
+                            title: { text: "Approve or deny score report", variant: "primary" },
+                            content: ["proposed-report", "deny-editor"],
+                            footer: warningFooter,
+                            buttons: this.denyEditor ? [
+                                { click: () => { this.$refs["deny-editor"].scoreReportConfirmModal = true; }, style: { variant: "success", icon: "fas fa-check", text: "Submit counter report" } },
+                                { click: () => { this.denyEditor = false; }, style: { variant: "secondary", icon: "fas fa-times", text: "Cancel counter edit" } }
+                            ] : [
+                                { disabled: this.denyEditor, reaction: "approve", action: "approve-score-report", style: { variant: "success", icon: "fas fa-check", text: "Approve" } },
+                                { click: () => { this.denyEditor = true; }, style: { variant: "danger", icon: "fas fa-times", text: "Deny & counter" } }
+                            ]
+                        },
+                        staff: (this.existingScoreReport?.approved_by_staff && !this.existingScoreReport?.denied_by_staff)
+                            ? {
+                                title: {
+                                    text: "Score report pre-approved",
+                                    variant: "success"
+                                },
+                                content: ["proposed-report", "log"],
+                                buttons: [
+                                    {
+                                        reaction: "force-approve",
+                                        action: "staff-approve-score-report",
+                                        style: {
+                                            variant: "primary",
+                                            icon: "fas fa-shield-check",
+                                            text: "Force approve"
+                                        },
+                                        successToast: "Score report force approved"
+                                    },
+                                    ...this.eventSettings?.reporting?.score?.staffApprove ? [{
+                                        reaction: "pre-approve",
+                                        action: "staff-approve-score-report",
+                                        disabled: true,
+                                        successToast: "Score report pre-approved",
+                                        style: {
+                                            variant: "success",
+                                            icon: "fas fa-check",
+                                            text: "Pre-approve"
+                                        }
+                                    }] : [],
+                                    {
+                                        reaction: "deny",
+                                        action: "staff-approve-score-report",
+                                        style: {
+                                            variant: "danger",
+                                            icon: "fas fa-times",
+                                            text: "Deny"
+                                        },
+                                        successToast: "Score report denied"
+                                    },
+                                    // { reaction: "delete", action: "staff-approve-score-report", style: { variant: "danger", icon: "fas fa-trash", text: "Delete" }, successToast: `Score report deleted` },
+                                ],
+                                footer: [{ heading: "Waiting for opponent approval", icon: "fas fa-clock" }]
+                            }
+                            : {
+                                title: {
+                                    text: this.eventSettings?.reporting?.score?.staffApprove ? "Pre-approve score report" : "Score report waiting for opponent approval",
+                                    variant: "primary"
+                                },
+                                content: ["information", "proposed-report"],
+                                buttons: [
+                                    {
+                                        reaction: "force-approve",
+                                        action: "staff-approve-score-report",
+                                        style: {
+                                            variant: "primary",
+                                            icon: "fas fa-shield-check",
+                                            text: "Force approve"
+                                        },
+                                        successToast: "Score report force approved"
+                                    },
+                                    ...this.eventSettings?.reporting?.score?.staffApprove ? [{
+                                        reaction: "pre-approve",
+                                        action: "staff-approve-score-report",
+                                        successToast: "Score report pre-approved",
+                                        style: {
+                                            variant: "success",
+                                            icon: "fas fa-check",
+                                            text: "Pre-approve"
+                                        }
+                                    }] : [],
+                                    {
+                                        reaction: "deny",
+                                        action: "staff-approve-score-report",
+                                        style: {
+                                            variant: "danger",
+                                            icon: "fas fa-times",
+                                            text: "Deny"
+                                        },
+                                        successToast: "Score report denied & locked"
+                                    },
+                                ],
+                                footer: warningFooter
+                            },
+                    }
                 };
 
                 if (this.existingScoreReport?.approved_by_opponent) {
@@ -369,16 +627,106 @@ export default {
                     title: "Opponent approval",
                     description: "Opponent approvals not needed on this match",
                     status: "disabled",
-                    icon: "fas fa-check"
+                    icon: "fas fa-check",
+                    actions: {
+                        teams: {
+                            title: { text: "Waiting for staff approval" },
+                            content: ["proposed-report"],
+                            footer: warningFooter
+                        },
+                        staff: (this.existingScoreReport?.approved_by_staff && !this.existingScoreReport?.denied_by_staff)
+                            ? {
+                                title: {
+                                    text: "Score report pre-approved",
+                                    variant: "success"
+                                },
+                                content: ["proposed-report", "log"],
+                                buttons: [
+                                    {
+                                        reaction: "force-approve",
+                                        action: "staff-approve-score-report",
+                                        style: {
+                                            variant: "primary",
+                                            icon: "fas fa-shield-check",
+                                            text: "Force approve"
+                                        },
+                                        successToast: "Score report force approved"
+                                    },
+                                    ...this.eventSettings?.reporting?.score?.staffApprove ? [{
+                                        reaction: "pre-approve",
+                                        action: "staff-approve-score-report",
+                                        disabled: true,
+                                        successToast: "Score report pre-approved",
+                                        style: {
+                                            variant: "success",
+                                            icon: "fas fa-check",
+                                            text: "Pre-approve"
+                                        }
+                                    }] : [],
+                                    {
+                                        reaction: "deny",
+                                        action: "staff-approve-score-report",
+                                        style: {
+                                            variant: "danger",
+                                            icon: "fas fa-times",
+                                            text: "Deny"
+                                        },
+                                        successToast: "Score report denied"
+                                    },
+                                    // { reaction: "delete", action: "staff-approve-score-report", style: { variant: "danger", icon: "fas fa-trash", text: "Delete" }, successToast: `Score report deleted` },
+                                ],
+                                footer: [{ heading: "Waiting for opponent approval", icon: "fas fa-clock" }]
+                            }
+                            : {
+                                title: {
+                                    text: this.eventSettings?.reporting?.score?.staffApprove ? "Pre-approve score report" : "Score report waiting for opponent approval",
+                                    variant: "primary"
+                                },
+                                content: ["information", "proposed-report"],
+                                buttons: [
+                                    {
+                                        reaction: "force-approve",
+                                        action: "staff-approve-score-report",
+                                        style: {
+                                            variant: "primary",
+                                            icon: "fas fa-shield-check",
+                                            text: "Force approve"
+                                        },
+                                        successToast: "Score report force approved"
+                                    },
+                                    ...this.eventSettings?.reporting?.score?.staffApprove ? [{
+                                        reaction: "pre-approve",
+                                        action: "staff-approve-score-report",
+                                        successToast: "Score report pre-approved",
+                                        style: {
+                                            variant: "success",
+                                            icon: "fas fa-check",
+                                            text: "Pre-approve"
+                                        }
+                                    }] : [],
+                                    {
+                                        reaction: "deny",
+                                        action: "staff-approve-score-report",
+                                        style: {
+                                            variant: "danger",
+                                            icon: "fas fa-times",
+                                            text: "Deny"
+                                        },
+                                        successToast: "Score report denied & locked"
+                                    },
+                                ],
+                                footer: this.eventSettings?.reporting?.score?.staffApprove ?
+                                    [{ heading: "This event requires staff approval", icon: "fas fa-exclamation-circle" }] :
+                                    [{ heading: "This event does not require staff approval", icon: "fas fa-check" }]
+                            },
+                    }
                 });
             }
 
             if (this.existingScoreReport?.countered_by_opponent) {
                 steps[steps.length-1].status = "countered";
                 steps[steps.length-1].icon = "fas fa-exchange";
-                if (this.opponentTeam?.name) {
-                    steps[steps.length-1].description = `${this.opponentTeam.name} submitted a counter report`;
-                }
+                steps[steps.length-1].description = `${this.opponentTeam?.name || "Opponent"} submitted a counter report`;
                 steps.push(
                     {
                         key: "counterReportApprove",
@@ -386,7 +734,47 @@ export default {
                         title: "Counter approval",
                         description: `${this.existingScoreReport?.team?.name || "Original team"} approves counter report`,
                         status: "inactive",
-                        icon: "fas fa-clipboard-list"
+                        icon: "fas fa-clipboard-list",
+                        actions: {
+                            submitter: {
+                                title: { text: "Approve or deny counter report", variant: "primary" },
+                                content: ["proposed-report", "proposed-counter-report"],
+                                footer: [...warningFooter].filter(Boolean),
+                                buttons: [
+                                    { reaction: "counter-approve", action: "approve-score-report", style: { variant: "success", icon: "fas fa-check", text: "Approve counter" } },
+                                    { reaction: "counter-deny", action: "approve-score-report", style: { variant: "danger", icon: "fas fa-times", text: "Deny counter" } }
+                                ]
+                            },
+                            opponent: {
+                                title: { text: "Counter report submitted" },
+                                content: ["proposed-report", "proposed-counter-report"],
+                                footer: [{ heading: "Waiting for an opponent's response", icon: "fas fa-clock" }, ...warningFooter].filter(Boolean)
+                            },
+                            staff: {
+                                content: ["proposed-report", "proposed-counter-report"],
+                                buttons: [
+                                    { reaction: "force-approve", action: "staff-approve-score-report", style: { variant: "primary", icon: "fas fa-shield-check", text: "Force-approve original" }, tooltip: "Force-approve the original report" },
+                                    { reaction: "pre-approve", action: "staff-approve-score-report", style: { variant: "success", icon: "fas fa-check", text: "Pre-approve" }, tooltip: "Auto approve this report once the counter report is approved by both teams" },
+                                    { reaction: "deny", action: "staff-approve-score-report", style: { variant: "danger", icon: "fas fa-times", text: "Deny" }, tooltip: "Force deny this report" },
+                                    { reaction: "force-counter-approve", action: "staff-approve-score-report", style: { variant: "primary", icon: "fas fa-shield-check", text: "Force-approve counter" }, tooltip: "Force-approve the counter report without waiting for team approval" },
+                                ]
+                            }
+                            // staff: this.existingScoreReport?.approved_by_staff && !this.existingScoreReport?.denied_by_staff ?
+                            //     {
+                            //         title: { text: "Report pre-approved", variant: "success" },
+                            //         content: ["proposed-report", "proposed-counter-report"],
+                            //
+                            //     } : (this.eventSettings?.reporting?.score?.staffApprove ?
+                            //         {
+                            //             title: { text: "Pre-approve report", variant: "primary" },
+                            //             content: ["proposed-report", "proposed-counter-report"],
+                            //
+                            //         } : {
+                            //             title: { text: "Counter report submitted" },
+                            //             content: ["proposed-report", "proposed-counter-report"],
+                            //
+                            //         })
+                        }
                     }
                 );
 
@@ -399,14 +787,41 @@ export default {
                     title: "Staff approval",
                     description: "Staff member approves the report",
                     status: "inactive",
-                    icon: "fas fa-clipboard-check"
+                    icon: "fas fa-clipboard-check",
+                    actions: {
+                        teams: {
+                            title: { text: "Waiting for staff approval" },
+                            content: ["proposed-report"],
+                            footer: warningFooter
+                        },
+                        staff: {
+                            title: { text: "Approve or deny score report" },
+                            content: ["proposed-report"],
+                            footer: warningFooter,
+                            buttons: [
+                                {
+                                    reaction: "approve",
+                                    action: "staff-approve-score-report",
+                                    style: {
+                                        variant: "success",
+                                        icon: "fas fa-check",
+                                        text: "Approve"
+                                    }
+                                },
+                                {
+                                    reaction: "delete",
+                                    action: "staff-approve-score-report",
+                                    style: {
+                                        variant: "danger",
+                                        icon: "fas fa-times",
+                                        text: "Deny"
+                                    }
+                                }
+                            ]
+                        }
+                    }
                 };
-
-                if (this.existingScoreReport?.force_approved) {
-                    newStep.status = "complete";
-                    newStep.icon = "fas fa-shield-check";
-                    newStep.description = "Staff member force approved this report";
-                } else if (this.existingScoreReport?.approved_by_staff) {
+                if (this.existingScoreReport?.approved_by_staff) {
                     newStep.status = "complete";
                     newStep.icon = "fas fa-check";
                 }
@@ -422,6 +837,12 @@ export default {
                 });
             }
 
+            if (this.existingScoreReport?.force_approved) {
+                steps[steps.length - 1].status = "complete";
+                steps[steps.length - 1].icon = "fas fa-shield-check";
+                steps[steps.length - 1].description = "Staff member force approved this report";
+            }
+
             let firstAvailable = steps.findIndex(s => s.status === "inactive");
             if (firstAvailable !== -1) {
                 steps[firstAvailable].status = "active";
@@ -435,8 +856,25 @@ export default {
     },
     methods: {
         url,
+        async actionButtonPress(button) {
+            this.processing = true;
+            try {
+                const response = await authenticatedRequest(`actions/${button.action}`, {
+                    matchID: this.match.id,
+                    reaction: button.reaction
+                });
+
+                if (!response.error) {
+                    this.$notyf.success(`Success: ${button.successToast || button.style.text.toLowerCase()}`);
+                }
+
+            } finally {
+                this.processing = false;
+                this.proposedTime = null;
+            }
+        },
         async approveReport(reaction) {
-            this.processing.approval = true;
+            this.processing = true;
             try {
                 const response = await authenticatedRequest("actions/approve-score-report", {
                     matchID: this.match.id,
@@ -448,11 +886,11 @@ export default {
                 }
 
             } finally {
-                this.processing.approval = false;
+                this.processing = false;
             }
         },
         async staffApproveReport(reaction) {
-            this.processing.approval = true;
+            this.processing = true;
             try {
                 const response = await authenticatedRequest("actions/staff-approve-score-report", {
                     matchID: this.match.id,
@@ -464,7 +902,7 @@ export default {
                 }
 
             } finally {
-                this.processing.approval = false;
+                this.processing = false;
             }
         }
     },
@@ -472,6 +910,8 @@ export default {
 </script>
 
 <style scoped>
+    @import "match-editors.css";
+
     .score-reporting-status {
         max-width: min(500px, 75%)
     }
@@ -513,5 +953,9 @@ export default {
         display: flex;
         flex-direction: column;
         max-width: 100%;
+    }
+
+    .score-reporting-container>div:not(.report-steps-top):not(.action-container) {
+        outline: 3px solid red;
     }
 </style>

--- a/website/src/views/sub-views/ThingTheme.vue
+++ b/website/src/views/sub-views/ThingTheme.vue
@@ -15,11 +15,11 @@
         <div class="theme-collection mb-3">
             <div class="theme-bar default-thing" :style="mainTheme">
                 <div class="text flex-center flex-grow-1 px-3">Theme</div>
-                <contrast-badge class="contrast-badge" :contrast="calculateContrastHex(mainTheme.color, mainTheme.backgroundColor)" />
+                <ContrastBadge class="contrast-badge" :contrast="calculateContrastHex(mainTheme.color, mainTheme.backgroundColor)" />
             </div>
             <div class="theme-bar default-thing" :style="logoBackground">
                 <div class="text flex-center flex-grow-1 px-3">Logo Background</div>
-                <contrast-badge class="contrast-badge" :contrast="calculateContrastHex(logoBackground.color, logoBackground.backgroundColor)" />
+                <ContrastBadge class="contrast-badge" :contrast="calculateContrastHex(logoBackground.color, logoBackground.backgroundColor)" />
             </div>
         </div>
 
@@ -38,7 +38,7 @@
 
             <div class="discord-list d-flex flex-column gap-1 mb-3">
                 <div v-for="color in discordColors" :key="color.name" class="discord-test d-flex gap-2">
-                    <contrast-badge class="contrast-badge" :contrast="color.contrast" />
+                    <ContrastBadge class="contrast-badge" :contrast="color.contrast" />
                     <div class="color-test d-flex gap-2" :style="{color: color.value}">
                         <div>{{ thing?.name }}</div>
                         <div class="fw-bold">{{ thing?.name }}</div>
@@ -61,7 +61,7 @@
                             <div class="color-hex text-center flex-grow-1">
                                 <copy-text-button :no-icon="true">{{ safeColor(text.value) }}</copy-text-button>
                             </div>
-                            <contrast-badge class="contrast-badge" :contrast="text.contrast" />
+                            <ContrastBadge class="contrast-badge" :contrast="text.contrast" />
                         </div>
                     </div>
                 </div>
@@ -135,6 +135,7 @@ import CopyTextButton from "@/components/website/CopyTextButton";
 import { calculateContrastHex, url } from "@/utils/content-utils";
 import { mapWritableState } from "pinia";
 import { useSettingsStore } from "@/stores/settingsStore";
+import ContrastBadge from "@/components/website/ContrastBadge.vue";
 
 function cleanKey(key) {
     return key.replace(/_/g, " ");
@@ -142,7 +143,7 @@ function cleanKey(key) {
 
 export default {
     name: "ThingTheme",
-    components: { CopyTextButton, /* HeroColorControls, RecoloredHero, */ BracketTeam, IngameTeam, ContentRow, ContentThing, StandingsTeam },
+    components: { ContrastBadge, CopyTextButton, /* HeroColorControls, RecoloredHero, */ BracketTeam, IngameTeam, ContentRow, ContentThing, StandingsTeam },
     props: ["team", "event"],
     computed: {
         ...mapWritableState(useSettingsStore, ["removeHashInHex"]),

--- a/website/src/views/sub-views/event-settings/EventSettingsDiscordLogging.vue
+++ b/website/src/views/sub-views/event-settings/EventSettingsDiscordLogging.vue
@@ -4,7 +4,7 @@
             <b-form-group
                 label="Server"
                 label-for="server-input"
-                label-cols="2"
+                label-cols="3"
                 class="opacity-changes"
                 :class="{'low-opacity': processing['guild_id'] }">
                 <div class="d-flex gap-2">
@@ -17,85 +17,117 @@
             </b-form-group>
         </div>
 
-        <div>
-            <h3>Logging</h3>
-            <div class="logging settings-group d-flex flex-column gap-4">
-                <div class="d-flex flex-column gap-1">
-                    <b-form-group
-                        label="Public roster changes"
-                        label-cols="2"
-                        description="A public message when someone is added to or removed from teams.">
-                        <b-form-select
-                            v-model="logging.publicRosterChanges"
-                            :options="[{value:null,text:'Do not log'},...(channelData||[])]" />
-                    </b-form-group>
-                    <b-form-group
-                        label="Hide non-staff roster changes"
-                        label-cols="2"
-                        description="Don't log any changes about team members who aren't players.">
-                        <b-form-checkbox
-                            v-model="logging.hideNonStaffRosterChanges" />
-                    </b-form-group>
-                    <b-form-group
-                        disabled
-                        label="Match time changes"
-                        label-cols="2"
-                        description="A public message when the start time of a match changes.">
-                        <b-form-select
-                            v-model="logging.matchTimeChanges"
-                            :options="[{value:null,text:'Do not log'},...(channelData||[])]" />
-                    </b-form-group>
+
+        <div class="border border-secondary bg-dark rounded p-2 px-3 d-flex flex-column gap-4">
+            <div class="d-flex justify-content-between align-items-center">
+                <h2 class="m-0">Logging & notification channels</h2>
+                <b-button variant="success" :disabled="processing.save" @click="saveToEvent">
+                    <i class="fas fa-save fa-fw"></i>
+                    Save logging channels
+                </b-button>
+            </div>
+
+            <div>
+                <h3>Public</h3>
+
+                <div class="logging settings-group d-flex flex-column gap-4">
+                    <div class="d-flex flex-column gap-2">
+                        <b-form-group
+                            label="Public roster changes"
+                            label-cols="3"
+                            :label-class="logging.publicRosterChanges ? 'active-channel' : ''"
+                            description="A public message when someone is added to or removed from teams.">
+                            <b-form-select
+                                v-model="logging.publicRosterChanges"
+                                :options="[{value:null,text:'Do not log'},...(channelData||[])]" />
+                        </b-form-group>
+                        <b-form-group
+                            label="Hide non-staff roster changes"
+                            label-cols="3"
+                            description="Don't log any changes about team members who aren't players.">
+                            <b-form-checkbox
+                                v-model="logging.hideNonStaffRosterChanges" />
+                        </b-form-group>
+                        <b-form-group
+                            label="Match time changes"
+                            :label-class="logging.matchTimeChanges ? 'active-channel' : ''"
+                            label-cols="3"
+                            description="A public message when the start time of a match changes.">
+                            <b-form-select
+                                v-model="logging.matchTimeChanges"
+                                :options="[{value:null,text:'Do not log'},...(channelData||[])]" />
+                        </b-form-group>
+                        <b-form-group
+                            label="Post-match reports"
+                            :label-class="logging.postMatchReports ? 'active-channel' : ''"
+                            label-cols="3"
+                            description="A public message with match details once a match has been completed.">
+                            <b-form-select
+                                v-model="logging.postMatchReports"
+                                :options="[{value:null,text:'Do not log'},...(channelData||[])]" />
+                        </b-form-group>
+                    </div>
                 </div>
             </div>
-        </div>
-        <div>
-            <h3>Score reporting</h3>
-            <div class="logging settings-group d-flex flex-column gap-4">
-                <div class="d-flex flex-column gap-1">
-                    <b-form-group
-                        label="Captain notifications"
-                        label-cols="2"
-                        description="A message in a captains channel notifying teams that a score needs approval">
-                        <b-form-select
-                            v-model="logging.captainNotifications"
-                            :options="[{value:null,text:'Do not log'},...(channelData||[])]" />
-                    </b-form-group>
-                    <b-form-group
-                        label="Post-match reports"
-                        label-cols="2"
-                        description="A public message with match details once a match has been completed.">
-                        <b-form-select
-                            v-model="logging.postMatchReports"
-                            :options="[{value:null,text:'Do not log'},...(channelData||[])]" />
-                    </b-form-group>
-                </div>
-                <div class="d-flex flex-column gap-2">
-                    <b-form-group
-                        label="Staff score report notifications"
-                        label-cols="2"
-                        description="A staff message prompting staff approval of a score report.">
-                        <b-form-select
-                            v-model="logging.staffScoreReport"
-                            :options="[{value:null,text:'Do not log'},...(channelData||[])]" />
-                    </b-form-group>
-                    <b-form-group
-                        label="Score report completions"
-                        label-cols="2"
-                        description="A staff message detailing a completed score report.">
-                        <b-form-select
-                            v-model="logging.staffCompletedScoreReport"
-                            :options="[{value:null,text:'Do not log'},...(channelData||[])]" />
-                    </b-form-group>
+
+            <div>
+                <h3>Staff</h3>
+                <div class="logging settings-group d-flex flex-column gap-4">
+                    <div class="d-flex flex-column gap-2">
+                        <b-form-group
+                            label="Staff notifications"
+                            :label-class="logging.staffApprovalNotifications ? 'active-channel' : ''"
+                            label-cols="3"
+                            description="A staff channel for notifications.">
+                            <b-form-select
+                                v-model="logging.staffApprovalNotifications"
+                                :options="[{value:null,text:'Do not log'},...(channelData||[])]" />
+                        </b-form-group>
+                        <b-form-group
+                            label="Send staff pre-approval notifications"
+                            label-cols="3"
+                            :label-class="logging.sendStaffPreapprovalNotifications ? 'active-channel' : ''"
+                            description="Send pre-approval notifications to staff notification channel">
+                            <b-form-checkbox
+                                v-model="logging.sendStaffPreapprovalNotifications" />
+                        </b-form-group>
+                        <b-form-group
+                            label="Staff score report notifications"
+                            :label-class="logging.staffScoreReport ? 'active-channel' : ''"
+                            label-cols="3"
+                            description="A staff message prompting staff approval of a score report.">
+                            <b-form-select
+                                v-model="logging.staffScoreReport"
+                                :options="[{value:null,text:'Do not log'},...(channelData||[])]" />
+                        </b-form-group>
+                        <b-form-group
+                            label="Score report completions"
+                            :label-class="logging.staffCompletedScoreReport ? 'active-channel' : ''"
+                            label-cols="3"
+                            description="A staff message detailing a completed score report.">
+                            <b-form-select
+                                v-model="logging.staffCompletedScoreReport"
+                                :options="[{value:null,text:'Do not log'},...(channelData||[])]" />
+                        </b-form-group>
+                    </div>
                 </div>
             </div>
-        </div>
-
-
-        <div class="d-flex justify-content-end">
-            <b-button variant="success" :disabled="processing.save" @click="saveToEvent">
-                <i class="fas fa-save fa-fw"></i>
-                Save logging channels
-            </b-button>
+            <div>
+                <h3>Captains</h3>
+                <div class="logging settings-group d-flex flex-column gap-4">
+                    <div class="d-flex flex-column gap-2">
+                        <b-form-group
+                            label="Captain notifications"
+                            :label-class="logging.captainNotifications ? 'active-channel' : ''"
+                            label-cols="3"
+                            description="A channel for contacting team staff for reschedules or score reports.">
+                            <b-form-select
+                                v-model="logging.captainNotifications"
+                                :options="[{value:null,text:'Do not log'},...(channelData||[])]" />
+                        </b-form-group>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </template>
@@ -122,9 +154,12 @@ export default {
             postMatchReports: null,
             captainNotifications: null,
 
+            staffApprovalNotifications: null,
+
             staffScoreReport: null,
             staffCompletedScoreReport: null,
 
+            sendStaffPreapprovalNotifications: false,
             hideNonStaffRosterChanges: false
         }
     }),
@@ -278,5 +313,8 @@ export default {
 </script>
 
 <style scoped>
-
+    :deep(.active-channel) {
+        color: var(--success);
+        font-weight: bold;
+    }
 </style>

--- a/website/src/views/sub-views/event-settings/editor/ReportingEventSettingsGroup.vue
+++ b/website/src/views/sub-views/event-settings/editor/ReportingEventSettingsGroup.vue
@@ -1,48 +1,73 @@
 <template>
     <EventSettingsGroup title="Reporting">
-        <div class="py-2">
-            <event-settings-checkbox
-                :active="reportingData?.score?.use"
-                @update:active="val => updateData('score', 'use', val)">
-                Allow map score reporting
-            </event-settings-checkbox>
-            <event-settings-checkbox
-                :active="reportingData?.score?.opponentApprove"
-                @update:active="val => updateData('score', 'opponentApprove', val)">
-                Opponents must approve
-            </event-settings-checkbox>
-            <event-settings-checkbox
-                :active="reportingData?.score?.staffApprove"
-                @update:active="val => updateData('score', 'staffApprove', val)">
-                Staff must approve
-            </event-settings-checkbox>
-        </div>
-        <b-form-group label="Editor settings" label-cols="3">
-            <div>
-                <event-settings-checkbox
-                    :active="reportingData?.score?.showHeroPicks"
-                    @update:active="val => updateData('score', 'showHeroPicks', val)">
-                    Show hero picks on maps
-                </event-settings-checkbox>
+        <div class="d-flex">
+            <div class="w-50 p-2">
+                <b>Match score reporting</b>
+                <div class="py-2">
+                    <event-settings-checkbox
+                        :active="reportingData?.score?.use"
+                        @update:active="val => updateData('score', 'use', val)">
+                        Allow map score reporting
+                    </event-settings-checkbox>
+                    <event-settings-checkbox
+                        :active="reportingData?.score?.opponentApprove"
+                        @update:active="val => updateData('score', 'opponentApprove', val)">
+                        Opponents must approve
+                    </event-settings-checkbox>
+                    <event-settings-checkbox
+                        :active="reportingData?.score?.staffApprove"
+                        @update:active="val => updateData('score', 'staffApprove', val)">
+                        Staff must approve
+                    </event-settings-checkbox>
+                </div>
+                <b-form-group label="Editor settings" label-cols="3">
+                    <div class="py-2">
+                        <event-settings-checkbox
+                            :active="reportingData?.score?.showHeroPicks"
+                            @update:active="val => updateData('score', 'showHeroPicks', val)">
+                            Show hero picks on maps
+                        </event-settings-checkbox>
 
-                <event-settings-checkbox
-                    :active="reportingData?.score?.showHeroBans"
-                    @update:active="val => updateData('score', 'showHeroBans', val)">
-                    Show hero bans on maps
-                </event-settings-checkbox>
+                        <event-settings-checkbox
+                            :active="reportingData?.score?.showHeroBans"
+                            @update:active="val => updateData('score', 'showHeroBans', val)">
+                            Show hero bans on maps
+                        </event-settings-checkbox>
 
-                <event-settings-checkbox
-                    :active="reportingData?.score?.showMapBans"
-                    @update:active="val => updateData('score', 'showMapBans', val)">
-                    Show map ban options
-                </event-settings-checkbox>
-                <event-settings-checkbox
-                    :active="reportingData?.score?.allowForfeits"
-                    @update:active="val => updateData('score', 'allowForfeits', val)">
-                    Allow forfeit reporting
-                </event-settings-checkbox>
+                        <event-settings-checkbox
+                            :active="reportingData?.score?.showMapBans"
+                            @update:active="val => updateData('score', 'showMapBans', val)">
+                            Show map ban options
+                        </event-settings-checkbox>
+                        <event-settings-checkbox
+                            :active="reportingData?.score?.allowForfeits"
+                            @update:active="val => updateData('score', 'allowForfeits', val)">
+                            Allow forfeit reporting
+                        </event-settings-checkbox>
+                    </div>
+                </b-form-group>
             </div>
-        </b-form-group>
+            <div class="w-50 p-2">
+                <b>Rescheduling</b>
+                <div class="py-2">
+                    <event-settings-checkbox
+                        :active="reportingData?.rescheduling?.use"
+                        @update:active="val => updateData('rescheduling', 'use', val)">
+                        Allow rescheduling
+                    </event-settings-checkbox>
+                    <event-settings-checkbox
+                        :active="reportingData?.rescheduling?.opponentApprove"
+                        @update:active="val => updateData('rescheduling', 'opponentApprove', val)">
+                        Opponents must approve
+                    </event-settings-checkbox>
+                    <event-settings-checkbox
+                        :active="reportingData?.rescheduling?.staffApprove"
+                        @update:active="val => updateData('rescheduling', 'staffApprove', val)">
+                        Staff must approve
+                    </event-settings-checkbox>
+                </div>
+            </div>
+        </div>
     </EventSettingsGroup>
 </template>
 
@@ -83,7 +108,8 @@ export default {
                 if (JSON.stringify(data) === JSON.stringify(this.reportingData)) return;
                 this.reportingData = data || {
                     attributes: {},
-                    score: {}
+                    score: {},
+                    rescheduling: {}
                 };
 
             }

--- a/website/src/views/sub-views/event-settings/editor/multiSelectEditor.js
+++ b/website/src/views/sub-views/event-settings/editor/multiSelectEditor.js
@@ -15,7 +15,7 @@ export class MultiSelectEditor extends Handsontable.editors.TextEditor {
         this.registerHooks();
 
         this.updateFunction = () => {};
-        this.localValue;
+        this.localValue = null;
 
         this.select.addEventListener("change", (e) => {
             console.log("select change", e.target.value);

--- a/website/src/views/sub-views/event/EventStaff.vue
+++ b/website/src/views/sub-views/event/EventStaff.vue
@@ -39,8 +39,6 @@
 <script>
 import ContentThing from "@/components/website/ContentThing.vue";
 import ContentRow from "@/components/website/ContentRow.vue";
-import EventStaffing from "@/components/website/EventStaffing.vue";
-import { url } from "@/utils/content-utils";
 
 export default {
     name: "EventStaff",

--- a/website/src/views/sub-views/event/EventStaffExtended.vue
+++ b/website/src/views/sub-views/event/EventStaffExtended.vue
@@ -9,7 +9,6 @@
 </template>
 <script>
 import EventStaffing from "@/components/website/EventStaffing.vue";
-import { url } from "@/utils/content-utils";
 
 export default {
     name: "EventStaffExtended",

--- a/website/src/views/sub-views/match-editors.css
+++ b/website/src/views/sub-views/match-editors.css
@@ -1,0 +1,52 @@
+.step-action {
+    display: flex;
+    flex-direction: column;
+    max-width: 100%;
+}
+
+
+.action-container {
+    border: 1px solid rgba(255,255,255,0.1);
+    border-radius: .5em;
+    width: 100%;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    overflow: hidden;
+}
+.action-title, .action-footer, .action-content {
+    display: flex;
+    padding: 0.5em 0.75em;
+    width: 100%;
+}
+.action-content {
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 1em;
+}
+.action-footer-buttons {
+    align-items: flex-end;
+}
+.action-title {
+    border-bottom: 1px solid rgba(255,255,255,0.1);
+    position: relative;
+}
+.action-footer {
+    border-top: 1px solid rgba(255,255,255,0.1);
+}
+.action-footer small {
+    padding: 0.25em 0;
+    line-height: 1.1;
+    display: block;
+}
+.title-spinner {
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 100%;
+    padding: 0 0.5em;
+    font-size: 0.8em;
+    font-weight: 400;
+}

--- a/website/src/views/sub-views/player/PlayerCasts.vue
+++ b/website/src/views/sub-views/player/PlayerCasts.vue
@@ -21,7 +21,6 @@
 </template>
 
 <script>
-import Match from "@/components/website/match/Match.vue";
 import { ReactiveArray, ReactiveThing } from "@/utils/reactive";
 import { sortEvents, sortMatches } from "@/utils/sorts";
 import { formatTime, url } from "@/utils/content-utils";


### PR DESCRIPTION
Building off the score reporting system, this is a new system for rescheduling match times by team agreement.

# Flow

![image](https://github.com/user-attachments/assets/bf3d803f-9dae-4627-9164-39bdf2bb8a93)

# Discord message reference

![image](https://github.com/user-attachments/assets/0168368c-c589-4cda-9ebf-cb523f77c5fd)


# General to-do list:

- [ ] Make sure Discord messages cover all events
- [ ] Investigate what should be done for persistent Discord messages (i.e. some denials won't trigger a message to be auto removed like other events where the process moves forwards)
- [ ] Lockdown server logic for all events
- [ ] Update sidebar/schedule badge to match logic
- [ ] Add Discord buttons for quick responses
